### PR TITLE
Vectorized stopping crit

### DIFF
--- a/qmcpy/accumulate_data/_accumulate_data.py
+++ b/qmcpy/accumulate_data/_accumulate_data.py
@@ -27,9 +27,8 @@ class AccumulateData(object):
         raise MethodImplementationError(self, 'update_data')
 
     def __repr__(self):
-        string = "Solution: %-15s\n" %str(self.solution)
-        for qmc_obj in [self.integrand, self.discrete_distrib, self.true_measure, self.stopping_crit]:
+        string = _univ_repr(self, 'AccumulateData', self.parameters + ['time_integrate'])
+        for qmc_obj in [self.stopping_crit, self.integrand, self.true_measure, self.discrete_distrib]:
             if qmc_obj:
-                string += str(qmc_obj)+'\n'
-        string += _univ_repr(self, 'AccumulateData', self.parameters + ['time_integrate'])
+                string += '\n'+str(qmc_obj)
         return string

--- a/qmcpy/accumulate_data/_accumulate_data.py
+++ b/qmcpy/accumulate_data/_accumulate_data.py
@@ -27,7 +27,7 @@ class AccumulateData(object):
         raise MethodImplementationError(self, 'update_data')
 
     def __repr__(self):
-        string = "Solution: %-15.4f\n" % (self.solution)
+        string = "Solution: %-15s\n" %str(self.solution)
         for qmc_obj in [self.integrand, self.discrete_distrib, self.true_measure, self.stopping_crit]:
             if qmc_obj:
                 string += str(qmc_obj)+'\n'

--- a/qmcpy/accumulate_data/ld_transform_bayes_data.py
+++ b/qmcpy/accumulate_data/ld_transform_bayes_data.py
@@ -70,7 +70,7 @@ class LDTransformBayesData(AccumulateData):
         self.ftilde_ = array([])  # fourier transformed integrand values
         if self.distribution_name == 'Lattice':
             # integrand after the periodization transform
-            self.ff = lambda x,*args,**kwargs: self.integrand.f_periodized(x,stopping_crit.ptransform,*args,**kwargs)
+            self.ff = lambda x,*args,**kwargs: self.integrand.f_periodized(x,stopping_crit.ptransform,*args,**kwargs).squeeze()
         else:
             self.ff = self.integrand.f
         self.fbt = fbt

--- a/qmcpy/accumulate_data/ld_transform_bayes_data.py
+++ b/qmcpy/accumulate_data/ld_transform_bayes_data.py
@@ -15,8 +15,6 @@ class LDTransformBayesData(AccumulateData):
     See the stopping criterion that utilize this object for references.
     """
 
-    parameters = ['n_total', 'solution', 'error_bound']
-
     def __init__(self, stopping_crit, integrand, true_measure, discrete_distrib, m_min: int, m_max: int,
                  fbt, merge_fbt, kernel):
         """
@@ -28,6 +26,7 @@ class LDTransformBayesData(AccumulateData):
             m_min (int): initial n == 2^m_min
             m_max (int): max n == 2^m_max
         """
+        self.parameters = ['solution','error_bound','n_total']
         self.stopping_crit = stopping_crit
         self.integrand = integrand
         self.true_measure = true_measure

--- a/qmcpy/accumulate_data/ld_transform_data.py
+++ b/qmcpy/accumulate_data/ld_transform_data.py
@@ -11,8 +11,6 @@ class LDTransformData(AccumulateData):
     See the stopping criterion that utilize this object for references.
     """
 
-    parameters = ['n_total','solution','error_bound']
-
     def __init__(self, stopping_crit, integrand, true_measure, discrete_distrib, coefv, 
         m_min, m_max, fudge, check_cone, ptransform, cast_complex,
         control_variates, control_variate_means, update_beta):
@@ -36,6 +34,7 @@ class LDTransformData(AccumulateData):
             control_variate_means (list): list of means for each control variate
             update_beta (bool): update control variate beta coefficients at each iteration? 
         """
+        self.parameters = ['solution','error_bound','n_total']
         self.stopping_crit = stopping_crit
         self.integrand = integrand
         self.true_measure = true_measure

--- a/qmcpy/accumulate_data/ld_transform_data.py
+++ b/qmcpy/accumulate_data/ld_transform_data.py
@@ -114,13 +114,13 @@ class LDTransformData(AccumulateData):
         # evaluate function (including CVs)
         n = int(2**self.m_min)
         if self.ncv==0: # not using control variates
-            y = self.integrand.f_periodized(self.x,self.ptransform)
+            y = self.integrand.f_periodized(self.x,self.ptransform).squeeze()
             yval = y.copy()
         else: # using control variates
             ycv = zeros((n,1+self.ncv),dtype=float)
-            ycv[:,0] = self.integrand.f_periodized(self.x,self.ptransform)
+            ycv[:,0] = self.integrand.f_periodized(self.x,self.ptransform).squeeze()
             for i in range(self.ncv):
-                ycv[:,i+1] = self.cv[i].f(self.x)
+                ycv[:,i+1] = self.cv[i].f(self.x).squeeze()
             y = ycv[:,0].copy()
             yval = y.copy()
             yg = ycv[:,1:].copy()
@@ -188,13 +188,13 @@ class LDTransformData(AccumulateData):
         mnext = int(self.m-1)
         n = int(2**mnext)
         if self.ncv==0: # not using control variates
-            ynext = self.integrand.f_periodized(self.x,self.ptransform)
+            ynext = self.integrand.f_periodized(self.x,self.ptransform).squeeze()
             yval = hstack((self.yval,ynext))
         else: # using control variates
             ycvnext = zeros((n,1+self.ncv),dtype=float)
-            ycvnext[:,0] = self.integrand.f_periodized(self.x,self.ptransform)
+            ycvnext[:,0] = self.integrand.f_periodized(self.x,self.ptransform).squeeze()
             for i in range(self.ncv):
-                ycvnext[:,i+1] = self.cv[i].f(self.x)
+                ycvnext[:,i+1] = self.cv[i].f(self.x).squeeze()
             ynext = ycvnext[:,0] - ycvnext[:,1:]@self.beta
             yval = hstack((self.yval,ynext))
         if self.cast_complex: 

--- a/qmcpy/accumulate_data/ld_transform_data.py
+++ b/qmcpy/accumulate_data/ld_transform_data.py
@@ -53,7 +53,7 @@ class LDTransformData(AccumulateData):
             if cv.discrete_distrib != self.discrete_distrib:
                 raise ParameterError('''
                         Each control variate's discrete distribution 
-                        must be the same instance as the one for te main integrand.''')
+                        must be the same instance as the one for the main integrand.''')
         self.cv_mu = array(self.cv_mu) # column vector
         self.ncv = int(len(self.cv))
         self.update_beta = update_beta

--- a/qmcpy/accumulate_data/mean_var_data.py
+++ b/qmcpy/accumulate_data/mean_var_data.py
@@ -68,16 +68,16 @@ class MeanVarData(AccumulateData):
                 new_dim = self.integrand._dim_at_level(l)
                 self.true_measure._set_dimension_r(new_dim)
                 samples = self.discrete_distrib.gen_samples(n=self.n[l])
-                y = self.integrand.f(samples,l=l)
+                y = self.integrand.f(samples,l=l).squeeze()
             else:
                 n = int(self.n[l])
                 samples = self.discrete_distrib.gen_samples(n)
-                y = self.integrand.f(samples)
+                y = self.integrand.f(samples).squeeze()
                 if self.ncv>0:
                     # using control variates
                     cvdata = zeros((n,self.ncv),dtype=float)
                     for i in range(self.ncv):
-                        cvdata[:,i] = self.cv[i].f(samples)
+                        cvdata[:,i] = self.cv[i].f(samples).squeeze()
                     cvmuhats = cvdata.mean(0)
                     if not hasattr(self,'beta_hat'):
                         # approximate control varite coefficient

--- a/qmcpy/accumulate_data/mean_var_data.py
+++ b/qmcpy/accumulate_data/mean_var_data.py
@@ -7,9 +7,6 @@ from numpy import *
 class MeanVarData(AccumulateData):
     """ Update and store mean and variance estimates. """
 
-    parameters = ['levels','solution','n','n_total','error_bound','confid_int']
-    EPS = finfo(float32).eps
-
     def __init__(self, stopping_crit, integrand, true_measure, discrete_distrib, n_init, control_variates, control_variate_means):
         """
         Args:
@@ -23,6 +20,8 @@ class MeanVarData(AccumulateData):
                 The same discrete distribution instance must be used for the integrand and each of the control variates. 
             control_variate_means (list): list of means for each control variate
         """
+        self.parameters = ['solution','error_bound','n_total','n','levels']
+        self.EPS = finfo(float32).eps
         self.stopping_crit = stopping_crit
         self.integrand = integrand
         self.true_measure = true_measure

--- a/qmcpy/accumulate_data/mean_var_data_rep.py
+++ b/qmcpy/accumulate_data/mean_var_data_rep.py
@@ -26,20 +26,20 @@ class MeanVarDataRep(AccumulateData):
         self.discrete_distrib = discrete_distrib
         # Set Attributes
         self.replications = int(replications)
-        self.ysums = zeros((self.replications,self.integrand.output_dims),dtype=float)
+        self.ysums = zeros((self.replications,self.integrand.dprime),dtype=float)
         self.solution = nan
         self.muhat = inf # sample mean
         self.sighat = inf # sample standard deviation
         self.t_eval = 0  # processing time for each integrand
-        self.n = n_init*ones(self.integrand.output_dims,dtype=float)  # current number of samples to draw from discrete distribution
-        self.nprev = zeros(self.integrand.output_dims,dtype=float) # previous number of samples drawn from discrete distributoin
+        self.n = n_init*ones(self.integrand.dprime,dtype=float)  # current number of samples to draw from discrete distribution
+        self.nprev = zeros(self.integrand.dprime,dtype=float) # previous number of samples drawn from discrete distributoin
         self.n_total = 0 # total number of samples across all replications
         self.confid_int = array([-inf, inf])  # confidence interval for solution
         # get seeds for each replication
         ld_seeds = self.discrete_distrib.rng.choice(100000,self.replications,replace=False).astype(dtype=uint64)+1
         self.ld_streams = [deepcopy(self.discrete_distrib) for r in range(self.replications)]
         for r in range(self.replications): self.ld_streams[r].set_seed(ld_seeds[r])
-        self.compute_flags = ones(self.integrand.output_dims)
+        self.compute_flags = ones(self.integrand.dprime)
         super(MeanVarDataRep,self).__init__()
 
     def update_data(self):
@@ -49,7 +49,7 @@ class MeanVarDataRep(AccumulateData):
         n_min = self.nprev[nmaxidx]
         for r in range(self.replications):
             x = self.ld_streams[r].gen_samples(n_min=n_min,n_max=n_max)
-            if self.integrand.output_dims>1:
+            if self.integrand.dprime>1:
                 y = self.integrand.f(x,compute_flags=self.compute_flags)
             else:
                 y = self.integrand.f(x)

--- a/qmcpy/accumulate_data/mean_var_data_rep.py
+++ b/qmcpy/accumulate_data/mean_var_data_rep.py
@@ -8,8 +8,6 @@ class MeanVarDataRep(AccumulateData):
     See the stopping criterion that utilize this object for references.
     """
 
-    parameters = ['solution','replications','sighat','n','n_total','error_bound','confid_int']
-
     def __init__(self, stopping_crit, integrand, true_measure, discrete_distrib, n_init, replications):
         """
         Args:
@@ -20,6 +18,7 @@ class MeanVarDataRep(AccumulateData):
             n_init (int): initial number of samples
             replications (int): number of replications
         """
+        self.parameters = ['solution','error_bound','n_total','n','replications']
         self.stopping_crit = stopping_crit
         self.integrand = integrand
         self.true_measure = true_measure

--- a/qmcpy/accumulate_data/mlmc_data.py
+++ b/qmcpy/accumulate_data/mlmc_data.py
@@ -60,7 +60,7 @@ class MLMCData(AccumulateData):
                 self.true_measure._set_dimension_r(self.dimensions[l])
                 # evaluate integral at sampleing points samples
                 samples = self.discrete_distrib.gen_samples(n=self.diff_n_level[l])
-                self.integrand.f(samples,l=l)
+                self.integrand.f(samples,l=l).squeeze()
                 self.n_level[l] = self.n_level[l] + self.diff_n_level[l]
                 self.sum_level[0,l] = self.sum_level[0,l] + self.integrand.sums[0]
                 self.sum_level[1,l] = self.sum_level[1,l] + self.integrand.sums[1]

--- a/qmcpy/accumulate_data/mlmc_data.py
+++ b/qmcpy/accumulate_data/mlmc_data.py
@@ -26,8 +26,8 @@ class MLMCData(AccumulateData):
             beta0 (float): variance is O(2^{-beta0*level})
             gamma0 (float): sample cost is O(2^{gamma0*level})
         """
-        self.parameters = ['levels','dimensions','n_level','mean_level','var_level', 
-            'cost_per_sample','n_total','alpha','beta','gamma']
+        self.parameters = ['solution','n_total','levels','n_level','dimensions','mean_level','var_level', 
+            'cost_per_sample','alpha','beta','gamma']
         self.stopping_crit = stopping_crit
         self.integrand = integrand
         self.true_measure = true_measure

--- a/qmcpy/accumulate_data/mlqmc_data.py
+++ b/qmcpy/accumulate_data/mlqmc_data.py
@@ -20,7 +20,7 @@ class MLQMCData(AccumulateData):
             discrete_distrib (DiscreteDistribution): a DiscreteDistribution instance
             replications (int): number of replications on each level
         """
-        self.parameters = ['levels','dimensions','n_level','mean_level','var_level','bias_estimate','n_total']
+        self.parameters = ['solution','n_total','n_level','levels','dimensions','mean_level','var_level','bias_estimate']
         self.stopping_crit = stopping_crit
         self.integrand = integrand
         self.true_measure = true_measure

--- a/qmcpy/accumulate_data/mlqmc_data.py
+++ b/qmcpy/accumulate_data/mlqmc_data.py
@@ -61,7 +61,7 @@ class MLQMCData(AccumulateData):
             for r in range(int(self.replications)):
                 self.discrete_distrib.set_seed(self.seeds[l,r]) # reset seed
                 samples = self.discrete_distrib.gen_samples(n_min=self.n_level[l],n_max=n_max)
-                self.integrand.f(samples,l=l)
+                self.integrand.f(samples,l=l).squeeze()
                 prev_sum = self.mean_level_reps[l,r]*self.n_level[l]
                 self.mean_level_reps[l,r] = (self.integrand.sums[0]+prev_sum)/float(n_max)
                 self.cost_level[l] = self.cost_level[l] + self.integrand.cost

--- a/qmcpy/discrete_distribution/iid_std_gaussian.py
+++ b/qmcpy/discrete_distribution/iid_std_gaussian.py
@@ -9,10 +9,10 @@ class IIDStdGaussian(DiscreteDistribution):
 
     >>> dd = IIDStdGaussian(dimension=2,seed=7)
     >>> dd.gen_samples(4)
-    array([[ 1.691e+00, -4.659e-01],
-           [ 3.282e-02,  4.075e-01],
-           [-7.889e-01,  2.066e-03],
-           [-8.904e-04, -1.755e+00]])
+    array([[ 1.69052570e+00, -4.65937371e-01],
+           [ 3.28201637e-02,  4.07516283e-01],
+           [-7.88923029e-01,  2.06557291e-03],
+           [-8.90385858e-04, -1.75472431e+00]])
     >>> dd
     IIDStdGaussian (DiscreteDistribution Object)
         d               2^(1)

--- a/qmcpy/discrete_distribution/iid_std_uniform.py
+++ b/qmcpy/discrete_distribution/iid_std_uniform.py
@@ -8,10 +8,10 @@ class IIDStdUniform(DiscreteDistribution):
 
     >>> dd = IIDStdUniform(dimension=2,seed=7)
     >>> dd.gen_samples(4)
-    array([[0.076, 0.78 ],
-           [0.438, 0.723],
-           [0.978, 0.538],
-           [0.501, 0.072]])
+    array([[0.07630829, 0.77991879],
+           [0.43840923, 0.72346518],
+           [0.97798951, 0.53849587],
+           [0.50112046, 0.07205113]])
     >>> dd
     IIDStdUniform (DiscreteDistribution Object)
         d               2^(1)

--- a/qmcpy/discrete_distribution/korobov/korobov.py
+++ b/qmcpy/discrete_distribution/korobov/korobov.py
@@ -12,15 +12,15 @@ class Korobov(DiscreteDistribution):
     
     >>> k = Korobov(2,generator=[1,3],seed=7)
     >>> k.gen_samples(4)
-    array([[0.982, 0.883],
-           [0.232, 0.633],
-           [0.482, 0.383],
-           [0.732, 0.133]])
+    array([[0.98196076, 0.88349207],
+           [0.23196076, 0.63349207],
+           [0.48196076, 0.38349207],
+           [0.73196076, 0.13349207]])
     >>> k.gen_samples(4)
-    array([[0.982, 0.883],
-           [0.232, 0.633],
-           [0.482, 0.383],
-           [0.732, 0.133]])
+    array([[0.98196076, 0.88349207],
+           [0.23196076, 0.63349207],
+           [0.48196076, 0.38349207],
+           [0.73196076, 0.13349207]])
     >>> k
     Korobov (DiscreteDistribution Object)
         d               2^(1)
@@ -29,10 +29,10 @@ class Korobov(DiscreteDistribution):
         seed            7
         mimics          StdUniform
     >>> Korobov(2,generator=[3,1],seed=7).gen_samples(4)
-    array([[0.982, 0.883],
-           [0.732, 0.133],
-           [0.482, 0.383],
-           [0.232, 0.633]])
+    array([[0.98196076, 0.88349207],
+           [0.73196076, 0.13349207],
+           [0.48196076, 0.38349207],
+           [0.23196076, 0.63349207]])
     
     References:
 
@@ -41,6 +41,16 @@ class Korobov(DiscreteDistribution):
         R package version 0.0-7.
         https://CRAN.R-project.org/package=qrng.
     """
+
+    korobov_qrng_cf = c_lib.korobov_qrng
+    korobov_qrng_cf.argtypes = [
+        ctypes.c_int,  # n
+        ctypes.c_int,  # d
+        ctypeslib.ndpointer(ctypes.c_int, flags='C_CONTIGUOUS'),  # generator
+        ctypes.c_int,  # randomize
+        ctypeslib.ndpointer(ctypes.c_double, flags='C_CONTIGUOUS'),  # result array 
+        ctypes.c_uint64]  # seed
+    korobov_qrng_cf.restype = None
 
     def __init__(self, dimension=1, generator=[1], randomize=True, seed=None):
         """
@@ -54,15 +64,7 @@ class Korobov(DiscreteDistribution):
             seed (int): seed the random number generator for reproducibility
         """
         self.parameters = ['d','generator','randomize','seed','mimics']
-        self.korobov_qrng_cf = c_lib.korobov_qrng
-        self.korobov_qrng_cf.argtypes = [
-            ctypes.c_int,  # n
-            ctypes.c_int,  # d
-            ctypeslib.ndpointer(ctypes.c_int, flags='C_CONTIGUOUS'),  # generator
-            ctypes.c_int,  # randomize
-            ctypeslib.ndpointer(ctypes.c_double, flags='C_CONTIGUOUS'),  # result array 
-            ctypes.c_uint64]  # seed
-        self.korobov_qrng_cf.restype = None
+        
         self.generator = array(generator, dtype=int32)
         self.randomize = randomize
         self.n_lim = 2**31

--- a/qmcpy/discrete_distribution/lattice/lattice.py
+++ b/qmcpy/discrete_distribution/lattice/lattice.py
@@ -11,12 +11,12 @@ class Lattice(DiscreteDistribution):
 
     >>> l = Lattice(2,seed=7)
     >>> l.gen_samples(4)
-    array([[0.076, 0.78 ],
-           [0.576, 0.28 ],
-           [0.326, 0.53 ],
-           [0.826, 0.03 ]])
+    array([[0.07630829, 0.77991879],
+           [0.57630829, 0.27991879],
+           [0.32630829, 0.52991879],
+           [0.82630829, 0.02991879]])
     >>> l.gen_samples(1)
-    array([[0.076, 0.78 ]])
+    array([[0.07630829, 0.77991879]])
     >>> l
     Lattice (DiscreteDistribution Object)
         d               2^(1)

--- a/qmcpy/discrete_distribution/sobol/sobol.py
+++ b/qmcpy/discrete_distribution/sobol/sobol.py
@@ -122,11 +122,11 @@ class Sobol(DiscreteDistribution):
         self.set_dim0(dim0)
         # set generating matrix
         z_root = dirname(abspath(__file__))+'/generating_matrices/'
-        if z_path is None:
+        if not z_path:
             self.d_max = 21201
             self.m_max = 32
-            self.msb = 2
-            self.z = empty(0,dtype=uint64)
+            self.msb = True
+            self.z = load(z_root+'sobol_mat.21201.32.msb.npy').astype(uint64)
         else:
             if isfile(z_path):
                 self.z = load(z_path).astype(uint64)

--- a/qmcpy/discrete_distribution/sobol/sobol.py
+++ b/qmcpy/discrete_distribution/sobol/sobol.py
@@ -13,12 +13,12 @@ class Sobol(DiscreteDistribution):
     
     >>> s = Sobol(2,seed=7)
     >>> s.gen_samples(4)
-    array([[0.429, 0.426],
-           [0.882, 0.552],
-           [0.025, 0.97 ],
-           [0.54 , 0.095]])
+    array([[0.4294895 , 0.42617749],
+           [0.88165111, 0.55154761],
+           [0.02512143, 0.96984807],
+           [0.53977577, 0.0954013 ]])
     >>> s.gen_samples(1)
-    array([[0.429, 0.426]])
+    array([[0.4294895 , 0.42617749]])
     >>> s
     Sobol (DiscreteDistribution Object)
         d               2^(1)

--- a/qmcpy/discrete_distribution/sobol/sobol_scipy.py
+++ b/qmcpy/discrete_distribution/sobol/sobol_scipy.py
@@ -1,6 +1,9 @@
 from .._discrete_distribution import DiscreteDistribution
 from ...util import ParameterError, ParameterWarning
-import scipy
+try:
+    from scipy.stats.qmc import Sobol as SobolScipyOG
+except:
+    raise ParameterError("scipy.stats.qmc.Sobol not found, try updating to scipy>=1.7.0")
 
 class SobolSciPy(DiscreteDistribution):
     """
@@ -42,7 +45,8 @@ class SobolSciPy(DiscreteDistribution):
            [0.25, 0.75]])
     >>> sobolscipy.gen_samples(n_min=6,n_max=8,warn=False) # uses scipy.stats.qmc.Sobol.fast_forward()
     array([[0.625, 0.125],
-           [0.125, 0.625]])"""
+           [0.125, 0.625]])
+    """
 
     def __init__(self, dimension=1, randomize=True, seed=None):
         """
@@ -55,7 +59,7 @@ class SobolSciPy(DiscreteDistribution):
         self.seed = seed
         self.d = dimension
         self.randomize = randomize
-        self.sobol = scipy.stats.qmc.Sobol(self.d,scramble=self.randomize,seed=seed)
+        self.sobol = SobolScipyOG(self.d,scramble=self.randomize,seed=seed)
         self.graycode = True
         self.low_discrepancy = True
         self.mimics = 'StdUniform'

--- a/qmcpy/discrete_distribution/sobol/sobol_scipy.py
+++ b/qmcpy/discrete_distribution/sobol/sobol_scipy.py
@@ -11,14 +11,14 @@ class SobolSciPy(DiscreteDistribution):
     
     >>> s = SobolSciPy(2,seed=7)
     >>> s.gen_samples(4)
-    array([[5.793e-01, 7.403e-01],
-           [4.158e-02, 6.921e-04],
-           [4.788e-01, 7.753e-01],
-           [8.925e-01, 4.838e-01]])
+    array([[5.79259991e-01, 7.40284680e-01],
+           [4.15829644e-02, 6.92069530e-04],
+           [4.78844851e-01, 7.75258362e-01],
+           [8.92499685e-01, 4.83783960e-01]])
     >>> s.gen_samples(1)
-    array([[0.579, 0.74 ]])
+    array([[0.57925999, 0.74028468]])
     >>> s.gen_samples(1)
-    array([[0.579, 0.74 ]])
+    array([[0.57925999, 0.74028468]])
     >>> s
     SobolSciPy (DiscreteDistribution Object)
         d               2^(1)

--- a/qmcpy/integrand/__init__.py
+++ b/qmcpy/integrand/__init__.py
@@ -4,3 +4,4 @@ from .keister import Keister
 from .linear0 import Linear0
 from .custom_fun import CustomFun
 from .ml_call_options import MLCallOptions
+from .x_to_vectorized_powers import XtoVectorizedPowers

--- a/qmcpy/integrand/_integrand.py
+++ b/qmcpy/integrand/_integrand.py
@@ -11,8 +11,8 @@ class Integrand(object):
         prefix = 'A concrete implementation of Integrand must have '
         if not (hasattr(self, 'true_measure') and isinstance(self.true_measure,TrueMeasure)):
             raise ParameterError(prefix + 'self.true_measure, a TrueMeasure instance')
-        if not (hasattr(self, 'output_dims')):
-            raise ParameterError('Set self.output_dims, the number of outputs for each input sample.')
+        if not (hasattr(self, 'dprime')):
+            raise ParameterError('Set self.dprime, the number of outputs for each input sample.')
         if not hasattr(self,'parameters'):
             self.parameters = []
         if not hasattr(self,'leveltype'):
@@ -50,12 +50,12 @@ class Integrand(object):
         if self.true_measure == self.true_measure.transform:
             # jacobian*weight/pdf will cancel so f(x) = g(\Psi(x))
             xtf = self.true_measure._transform(x) # get transformed samples, equivalent to self.true_measure._transform_r(x)
-            y = self.g(xtf,*args,**kwargs).reshape(n,self.output_dims)
+            y = self.g(xtf,*args,**kwargs).reshape(n,self.dprime)
         else: # using importance sampling --> need to compute pdf, jacobian(s), and weight explicitly
             pdf = self.discrete_distrib.pdf(x).reshape(n,1) # pdf of samples
             xtf,jacobians = self.true_measure.transform._jacobian_transform_r(x) # compute recursive transform+jacobian
             weight = self.true_measure._weight(xtf).reshape(n,1) # weight based on the true measure
-            gvals = self.g(xtf,*args,**kwargs).reshape(n,self.output_dims)
+            gvals = self.g(xtf,*args,**kwargs).reshape(n,self.dprime)
             y = gvals*weight/pdf*jacobians.reshape(n,1)
         return y
 

--- a/qmcpy/integrand/_integrand.py
+++ b/qmcpy/integrand/_integrand.py
@@ -7,7 +7,8 @@ from numpy import *
 class Integrand(object):
     """ Integrand abstract class. DO NOT INSTANTIATE. """
 
-    def __init__(self):
+    def __init__(self, output_dims):
+        self.output_dims = output_dims # outputs per sample
         prefix = 'A concrete implementation of Integrand must have '
         if not (hasattr(self, 'true_measure') and isinstance(self.true_measure,TrueMeasure)):
             raise ParameterError(prefix + 'self.true_measure, a TrueMeasure instance')
@@ -44,17 +45,18 @@ class Integrand(object):
         Return: 
             ndarray: length n vector of funciton evaluations
         """
+        n,d = x.shape
         if self.true_measure == self.true_measure.transform:
             # jacobian*weight/pdf will cancel so f(x) = g(\Psi(x))
             xtf = self.true_measure._transform(x) # get transformed samples, equivalent to self.true_measure._transform_r(x)
-            y = self.g(xtf,*args,**kwargs).squeeze()
+            y = self.g(xtf,*args,**kwargs).reshape(n,self.output_dims)
         else: # using importance sampling --> need to compute pdf, jacobian(s), and weight explicitly
-            pdf = self.discrete_distrib.pdf(x) # pdf of samples
+            pdf = self.discrete_distrib.pdf(x).reshape(n,1) # pdf of samples
             xtf,jacobians = self.true_measure.transform._jacobian_transform_r(x) # compute recursive transform+jacobian
-            weight = self.true_measure._weight(xtf) # weight based on the true measure
-            gvals = self.g(xtf,*args,**kwargs).squeeze()
-            y = gvals*weight/pdf*jacobians
-        return y.squeeze()
+            weight = self.true_measure._weight(xtf).reshape(n,1) # weight based on the true measure
+            gvals = self.g(xtf,*args,**kwargs).reshape(n,self.output_dims)
+            y = gvals*weight/pdf*jacobians.reshape(n,1)
+        return y
 
     def f_periodized(self, x, ptransform='NONE', *args, **kwargs):
         """
@@ -72,9 +74,10 @@ class Integrand(object):
         if self.discrete_distrib.mimics != 'StdUniform':
             raise ParameterError("f_periodized requires a discrete distribution that mimics a standard uniform measure.")
         ptransform = ptransform.upper()
+        n,d = x.shape
         if ptransform == 'BAKER': # Baker's transform
             xp = 1 - 2 * abs(x - 1 / 2)
-            w = 1
+            w = ones(n,dtype=float)
         elif ptransform == 'C0': # C^0 transform
             xp = 3 * x ** 2 - 2 * x ** 3
             w = prod(6 * x * (1 - x), 1)  
@@ -92,10 +95,10 @@ class Integrand(object):
             w = prod( (12 * pi - 8 * cos(2 * pi * x) * 2 * pi + sin(4 * pi * x) * 4 * pi) / (12 * pi), 1) # psi4_1
         elif ptransform == 'NONE':
             xp = x
-            w = 1
+            w = ones(n,dtype=float)
         else:
             raise ParameterError("The %s periodization transform is not implemented"%ptransform)
-        y = self.f(xp,*args,**kwargs)*w
+        y = self.f(xp,*args,**kwargs)*w.reshape(n,1)
         return y
         
     def _dim_at_level(self, l):

--- a/qmcpy/integrand/_integrand.py
+++ b/qmcpy/integrand/_integrand.py
@@ -7,11 +7,12 @@ from numpy import *
 class Integrand(object):
     """ Integrand abstract class. DO NOT INSTANTIATE. """
 
-    def __init__(self, output_dims):
-        self.output_dims = output_dims # outputs per sample
+    def __init__(self):
         prefix = 'A concrete implementation of Integrand must have '
         if not (hasattr(self, 'true_measure') and isinstance(self.true_measure,TrueMeasure)):
             raise ParameterError(prefix + 'self.true_measure, a TrueMeasure instance')
+        if not (hasattr(self, 'output_dims')):
+            raise ParameterError('Set self.output_dims, the number of outputs for each input sample.')
         if not hasattr(self,'parameters'):
             self.parameters = []
         if not hasattr(self,'leveltype'):

--- a/qmcpy/integrand/asian_option.py
+++ b/qmcpy/integrand/asian_option.py
@@ -88,7 +88,7 @@ class AsianOption(Integrand):
             self.dimensions = [self.true_measure.d]
             self.dim_fracs = [0.]
             self.leveltype = 'single'
-        self.output_dims = 1
+        self.dprime = 1
         super(AsianOption,self).__init__()    
 
     def _get_discounted_payoffs(self, stock_path, dimension):

--- a/qmcpy/integrand/asian_option.py
+++ b/qmcpy/integrand/asian_option.py
@@ -88,7 +88,8 @@ class AsianOption(Integrand):
             self.dimensions = [self.true_measure.d]
             self.dim_fracs = [0.]
             self.leveltype = 'single'
-        super(AsianOption,self).__init__(output_dims=1)    
+        self.output_dims = 1
+        super(AsianOption,self).__init__()    
 
     def _get_discounted_payoffs(self, stock_path, dimension):
         """

--- a/qmcpy/integrand/asian_option.py
+++ b/qmcpy/integrand/asian_option.py
@@ -88,7 +88,7 @@ class AsianOption(Integrand):
             self.dimensions = [self.true_measure.d]
             self.dim_fracs = [0.]
             self.leveltype = 'single'
-        super(AsianOption,self).__init__()        
+        super(AsianOption,self).__init__(output_dims=1)    
 
     def _get_discounted_payoffs(self, stock_path, dimension):
         """

--- a/qmcpy/integrand/custom_fun.py
+++ b/qmcpy/integrand/custom_fun.py
@@ -24,7 +24,8 @@ class CustomFun(Integrand):
         self.parameters = []
         self.true_measure = true_measure
         self._g = g
-        super(CustomFun,self).__init__(output_dims=1)
+        self.output_dims = 1
+        super(CustomFun,self).__init__()
     
     def g(self, t, *args, **kwargs):
         return self._g(t,*args,**kwargs)

--- a/qmcpy/integrand/custom_fun.py
+++ b/qmcpy/integrand/custom_fun.py
@@ -24,7 +24,7 @@ class CustomFun(Integrand):
         self.parameters = []
         self.true_measure = true_measure
         self._g = g
-        self.output_dims = 1
+        self.dprime = 1
         super(CustomFun,self).__init__()
     
     def g(self, t, *args, **kwargs):

--- a/qmcpy/integrand/custom_fun.py
+++ b/qmcpy/integrand/custom_fun.py
@@ -24,7 +24,7 @@ class CustomFun(Integrand):
         self.parameters = []
         self.true_measure = true_measure
         self._g = g
-        super(CustomFun,self).__init__()
+        super(CustomFun,self).__init__(output_dims=1)
     
     def g(self, t, *args, **kwargs):
         return self._g(t,*args,**kwargs)

--- a/qmcpy/integrand/european_option.py
+++ b/qmcpy/integrand/european_option.py
@@ -53,7 +53,7 @@ class EuropeanOption(Integrand):
         self.call_put = call_put.lower()
         if self.call_put not in ['call','put']:
             raise ParameterError("call_put must be either 'call' or 'put'")
-        self.output_dims = 1
+        self.dprime = 1
         super(EuropeanOption,self).__init__()  
 
     def g(self, t):

--- a/qmcpy/integrand/european_option.py
+++ b/qmcpy/integrand/european_option.py
@@ -53,7 +53,8 @@ class EuropeanOption(Integrand):
         self.call_put = call_put.lower()
         if self.call_put not in ['call','put']:
             raise ParameterError("call_put must be either 'call' or 'put'")
-        super(EuropeanOption,self).__init__(output_dims=1) # output dimensions per sample  
+        self.output_dims = 1
+        super(EuropeanOption,self).__init__()  
 
     def g(self, t):
         """ See abstract method. """

--- a/qmcpy/integrand/european_option.py
+++ b/qmcpy/integrand/european_option.py
@@ -53,7 +53,7 @@ class EuropeanOption(Integrand):
         self.call_put = call_put.lower()
         if self.call_put not in ['call','put']:
             raise ParameterError("call_put must be either 'call' or 'put'")
-        super(EuropeanOption,self).__init__()        
+        super(EuropeanOption,self).__init__(output_dims=1) # output dimensions per sample  
 
     def g(self, t):
         """ See abstract method. """

--- a/qmcpy/integrand/keister.py
+++ b/qmcpy/integrand/keister.py
@@ -47,7 +47,7 @@ class Keister(Integrand):
                 true measure by which to compose a transform
         """
         self.true_measure = Gaussian(sampler,mean=0,covariance=1/2)
-        self.output_dims = 1
+        self.dprime = 1
         super(Keister,self).__init__()
     
     def g(self, t):

--- a/qmcpy/integrand/keister.py
+++ b/qmcpy/integrand/keister.py
@@ -47,7 +47,7 @@ class Keister(Integrand):
                 true measure by which to compose a transform
         """
         self.true_measure = Gaussian(sampler,mean=0,covariance=1/2)
-        super(Keister,self).__init__()
+        super(Keister,self).__init__(output_dims=1)
     
     def g(self, t):
         d = t.shape[1]

--- a/qmcpy/integrand/keister.py
+++ b/qmcpy/integrand/keister.py
@@ -47,7 +47,8 @@ class Keister(Integrand):
                 true measure by which to compose a transform
         """
         self.true_measure = Gaussian(sampler,mean=0,covariance=1/2)
-        super(Keister,self).__init__(output_dims=1)
+        self.output_dims = 1
+        super(Keister,self).__init__()
     
     def g(self, t):
         d = t.shape[1]

--- a/qmcpy/integrand/linear0.py
+++ b/qmcpy/integrand/linear0.py
@@ -23,7 +23,7 @@ class Linear0(Integrand):
                 true measure by which to compose a transform
         """
         self.true_measure = Uniform(sampler, lower_bound=-.5, upper_bound=.5)
-        self.output_dims = 1
+        self.dprime = 1
         super(Linear0,self).__init__()
     
     def g(self, t):

--- a/qmcpy/integrand/linear0.py
+++ b/qmcpy/integrand/linear0.py
@@ -23,8 +23,8 @@ class Linear0(Integrand):
                 true measure by which to compose a transform
         """
         self.true_measure = Uniform(sampler, lower_bound=-.5, upper_bound=.5)
-        super(Linear0,self).__init__()
-
+        super(Linear0,self).__init__(output_dims=1)
+    
     def g(self, t):
         y = t.sum(1)
         return y

--- a/qmcpy/integrand/linear0.py
+++ b/qmcpy/integrand/linear0.py
@@ -23,7 +23,8 @@ class Linear0(Integrand):
                 true measure by which to compose a transform
         """
         self.true_measure = Uniform(sampler, lower_bound=-.5, upper_bound=.5)
-        super(Linear0,self).__init__(output_dims=1)
+        self.output_dims = 1
+        super(Linear0,self).__init__()
     
     def g(self, t):
         y = t.sum(1)

--- a/qmcpy/integrand/ml_call_options.py
+++ b/qmcpy/integrand/ml_call_options.py
@@ -65,7 +65,8 @@ class MLCallOptions(Integrand):
         self.b = .85*self.k
         self.leveltype = 'adaptive-multi'
         self.g_submodule = getattr(self,'_g_'+self.option)
-        super(MLCallOptions,self).__init__(output_dims=1)
+        self.output_dims = 1
+        super(MLCallOptions,self).__init__()
         #if self.discrete_distrib.low_discrepancy and self.option=='asian':
         #    raise ParameterError('MLCallOptions does not support LD sequence for Asian Option')
 

--- a/qmcpy/integrand/ml_call_options.py
+++ b/qmcpy/integrand/ml_call_options.py
@@ -65,7 +65,7 @@ class MLCallOptions(Integrand):
         self.b = .85*self.k
         self.leveltype = 'adaptive-multi'
         self.g_submodule = getattr(self,'_g_'+self.option)
-        super(MLCallOptions,self).__init__()
+        super(MLCallOptions,self).__init__(output_dims=1)
         #if self.discrete_distrib.low_discrepancy and self.option=='asian':
         #    raise ParameterError('MLCallOptions does not support LD sequence for Asian Option')
 

--- a/qmcpy/integrand/ml_call_options.py
+++ b/qmcpy/integrand/ml_call_options.py
@@ -65,7 +65,7 @@ class MLCallOptions(Integrand):
         self.b = .85*self.k
         self.leveltype = 'adaptive-multi'
         self.g_submodule = getattr(self,'_g_'+self.option)
-        self.output_dims = 1
+        self.dprime = 1
         super(MLCallOptions,self).__init__()
         #if self.discrete_distrib.low_discrepancy and self.option=='asian':
         #    raise ParameterError('MLCallOptions does not support LD sequence for Asian Option')

--- a/qmcpy/integrand/x_to_vectorized_powers.py
+++ b/qmcpy/integrand/x_to_vectorized_powers.py
@@ -12,14 +12,14 @@ class XtoVectorizedPowers(Integrand):
     >>> y1.shape
     (1024, 1)
     >>> y1.mean(0)
-    array([0.25])
+    array([0.25000036])
     >>> l2 = XtoVectorizedPowers(Sobol(2,seed=7), powers=[4,5])
     >>> x2 = l2.discrete_distrib.gen_samples(2**10)
     >>> y2 = l2.f(x2,compute_flags=[1,1])
     >>> y2.shape
     (1024, 2)
     >>> y2.mean(0)
-    array([0.4  , 0.333])
+    array([0.40000048, 0.33333393])
     """
 
     def __init__(self, sampler, powers=array([1,2])):

--- a/qmcpy/integrand/x_to_vectorized_powers.py
+++ b/qmcpy/integrand/x_to_vectorized_powers.py
@@ -8,7 +8,7 @@ class XtoVectorizedPowers(Integrand):
     """
     >>> l1 = XtoVectorizedPowers(Sobol(1,seed=7), powers=[3])
     >>> x1 = l1.discrete_distrib.gen_samples(2**10)
-    >>> y1 = l1.f(x1,compute_flags=[1])
+    >>> y1 = l1.f(x1)
     >>> y1.shape
     (1024, 1)
     >>> y1.mean(0)

--- a/qmcpy/integrand/x_to_vectorized_powers.py
+++ b/qmcpy/integrand/x_to_vectorized_powers.py
@@ -41,7 +41,8 @@ class XtoVectorizedPowers(Integrand):
         self.powers = array(powers)
         self.k = len(powers)
         self.true_measure = Uniform(sampler, lower_bound=0., upper_bound=1.)
-        super(XtoVectorizedPowers,self).__init__(output_dims=self.k) # output dimensions per sample
+        self.output_dims = self.k
+        super(XtoVectorizedPowers,self).__init__() # output dimensions per sample
 
     def g(self, t, compute_flags):
         n,d = t.shape

--- a/qmcpy/integrand/x_to_vectorized_powers.py
+++ b/qmcpy/integrand/x_to_vectorized_powers.py
@@ -41,7 +41,7 @@ class XtoVectorizedPowers(Integrand):
         self.powers = array(powers)
         self.k = len(powers)
         self.true_measure = Uniform(sampler, lower_bound=0., upper_bound=1.)
-        self.output_dims = self.k
+        self.dprime = self.k
         super(XtoVectorizedPowers,self).__init__() # output dimensions per sample
 
     def g(self, t, compute_flags):

--- a/qmcpy/integrand/x_to_vectorized_powers.py
+++ b/qmcpy/integrand/x_to_vectorized_powers.py
@@ -1,0 +1,53 @@
+from ._integrand import Integrand
+from ..discrete_distribution import Sobol
+from ..true_measure import Uniform
+from numpy import *
+
+
+class XtoVectorizedPowers(Integrand):
+    """
+    >>> l1 = XtoVectorizedPowers(Sobol(1,seed=7), powers=[3])
+    >>> x1 = l1.discrete_distrib.gen_samples(2**10)
+    >>> y1 = l1.f(x1,compute_flags=[1])
+    >>> y1.shape
+    (1024, 1)
+    >>> y1.mean(0)
+    array([0.25])
+    >>> l2 = XtoVectorizedPowers(Sobol(2,seed=7), powers=[4,5])
+    >>> x2 = l2.discrete_distrib.gen_samples(2**10)
+    >>> y2 = l2.f(x2,compute_flags=[1,1])
+    >>> y2.shape
+    (1024, 2)
+    >>> y2.mean(0)
+    array([0.4  , 0.333])
+    """
+
+    def __init__(self, sampler, powers=array([1,2])):
+        """
+        For (n by d)  sample x and k-vector powers = (p_0,...,p_{k-1}), 
+        return [
+            [x_{0,0}^p_0+x_{0,1}^p_0+...+x_{0,d-1}^p_0], ..., x_{0,0}^p_{k-1}+x_{0,1}^p_{k-1}+...+x_{0,d-1}^p_{k-1}],
+            ...
+            [[x_{n-1,0}^p_0+x_{n-1,1}^p_0+...+x_{n-1,d-1}^p_0], ..., x_{n-1,0}^p_{k-1}+x_{n-1,1}^p_{k-1}+...+x_{n-1,d-1}^p_{k-1}]]
+        ]
+        Essentially, if we return an (n by k) output Y, then Y[i,j] is sum(x[i,:]^powers[j])
+
+
+        Args:
+            sampler (DiscreteDistribution/TrueMeasure): A 
+                discrete distribution from which to transform samples or a
+                true measure by which to compose a transform
+        """
+        self.powers = array(powers)
+        self.k = len(powers)
+        self.true_measure = Uniform(sampler, lower_bound=0., upper_bound=1.)
+        super(XtoVectorizedPowers,self).__init__(output_dims=self.k) # output dimensions per sample
+
+    def g(self, t, compute_flags):
+        n,d = t.shape
+        Y = zeros((n,self.k),dtype=float)
+        for j in range(self.k):
+            if compute_flags[j] == 1: 
+                Y[:,j] = (t**self.powers[j]).sum(1)
+        return Y
+

--- a/qmcpy/integrand/x_to_vectorized_powers.py
+++ b/qmcpy/integrand/x_to_vectorized_powers.py
@@ -39,16 +39,19 @@ class XtoVectorizedPowers(Integrand):
                 true measure by which to compose a transform
         """
         self.powers = array(powers)
-        self.k = len(powers)
+        self.dprime = len(powers)
         self.true_measure = Uniform(sampler, lower_bound=0., upper_bound=1.)
-        self.dprime = self.k
+        self.g = self._g if self.dprime>1 else self._g1
         super(XtoVectorizedPowers,self).__init__() # output dimensions per sample
 
-    def g(self, t, compute_flags):
+    def _g(self, t, compute_flags):
         n,d = t.shape
-        Y = zeros((n,self.k),dtype=float)
-        for j in range(self.k):
+        Y = zeros((n,self.dprime),dtype=float)
+        for j in range(self.dprime):
             if compute_flags[j] == 1: 
                 Y[:,j] = (t**self.powers[j]).sum(1)
         return Y
+
+    def _g1(self, t):
+        return self._g(t, compute_flags=[1])
 

--- a/qmcpy/stopping_criterion/_cub_qmc_ld_g.py
+++ b/qmcpy/stopping_criterion/_cub_qmc_ld_g.py
@@ -1,0 +1,94 @@
+from ._stopping_criterion import StoppingCriterion
+from ..accumulate_data import LDTransformData
+from ..util import MaxSamplesWarning, ParameterError, ParameterWarning
+from numpy import *
+from time import time
+import warnings
+
+
+class _CubQMCLDG(StoppingCriterion):
+    """
+    Abstract class for CubQMC{LD}G where LD is a low discrepancy discrete distribution. 
+    See subclasses for implementation differences for each LD sequence. 
+    """
+
+    def __init__(self, integrand, abs_tol, rel_tol, n_init, n_max, fudge, check_cone,
+        control_variates, control_variate_means, update_beta, ptransform,
+        coefv, allowed_levels, allowed_distribs, cast_complex):
+        self.parameters = ['abs_tol','rel_tol','n_init','n_max']
+        # Input Checks
+        self.abs_tol = float(abs_tol)
+        self.rel_tol = float(rel_tol)
+        m_min = log2(n_init)
+        m_max = log2(n_max)
+        if m_min%1 != 0. or m_min < 8. or m_max%1 != 0.:
+            warning_s = '''
+                n_init and n_max must be a powers of 2.
+                n_init must be >= 2^8.
+                Using n_init = 2^10 and n_max=2^35.'''
+            warnings.warn(warning_s, ParameterWarning)
+            m_min = 10.
+            m_max = 35.
+        self.n_init = 2.**m_min
+        self.n_max = 2.**m_max
+        self.m_min = m_min
+        self.m_max = m_max
+        self.fudge = fudge
+        self.check_cone = check_cone
+        self.coefv = coefv
+        self.ptransform = ptransform
+        self.cast_complex = cast_complex
+        # QMCPy Objs
+        self.integrand = integrand
+        self.true_measure = self.integrand.true_measure
+        self.discrete_distrib = self.integrand.discrete_distrib
+        self.cv = control_variates
+        self.cv_mu = control_variate_means
+        self.ub = update_beta
+        # Verify Compliant Construction
+        super(_CubQMCLDG,self).__init__(allowed_levels, allowed_distribs)
+
+    def integrate(self):
+        """ See abstract method. """
+        # Construct AccumulateData Object to House Integration data
+        self.data = LDTransformData(self, self.integrand, self.true_measure, self.discrete_distrib,
+            self.coefv, self.m_min, self.m_max, self.fudge, self.check_cone, ptransform=self.ptransform, 
+            cast_complex=self.cast_complex, control_variates=self.cv, control_variate_means=self.cv_mu, update_beta=self.ub)
+        t_start = time()
+        while True:
+            self.data.update_data()
+            # Check the end of the algorithm
+            self.data.error_bound = self.data.fudge(self.data.m)*self.data.stilde
+            # Compute optimal estimator
+            ub = max(self.abs_tol, self.rel_tol*abs(self.data.solution + self.data.error_bound))
+            lb = max(self.abs_tol, self.rel_tol*abs(self.data.solution - self.data.error_bound))
+            self.data.solution = self.data.solution - self.data.error_bound*(ub-lb) / (ub+lb)
+            if 4*self.data.error_bound**2./(ub+lb)**2. <= 1.:
+                # stopping criterion met
+                break
+            elif self.data.m == self.data.m_max:
+                # doubling samples would go over n_max
+                warning_s = """
+                Alread generated %d samples.
+                Trying to generate %d new samples would exceed n_max = %d.
+                No more samples will be generated.
+                Note that error tolerances may no longer be satisfied""" \
+                % (int(2**self.data.m), int(2**self.data.m), int(2**self.data.m_max))
+                warnings.warn(warning_s, MaxSamplesWarning)
+                break
+            else:
+                # double sample size
+                self.data.m += 1.
+        self.data.time_integrate = time() - t_start
+        return self.data.solution, self.data
+    
+    def set_tolerance(self, abs_tol=None, rel_tol=None):
+        """
+        See abstract method. 
+        
+        Args:
+            abs_tol (float): absolute tolerance. Reset if supplied, ignored if not. 
+            rel_tol (float): relative tolerance. Reset if supplied, ignored if not. 
+        """
+        if abs_tol != None: self.abs_tol = abs_tol
+        if rel_tol != None: self.rel_tol = rel_tol

--- a/qmcpy/stopping_criterion/_cub_qmc_ld_g.py
+++ b/qmcpy/stopping_criterion/_cub_qmc_ld_g.py
@@ -6,7 +6,7 @@ from time import time
 import warnings
 
 
-class _CubQMCLDG(StoppingCriterion):
+class CubQMCLDG(StoppingCriterion):
     """
     Abstract class for CubQMC{LD}G where LD is a low discrepancy discrete distribution. 
     See subclasses for implementation differences for each LD sequence. 
@@ -46,7 +46,7 @@ class _CubQMCLDG(StoppingCriterion):
         self.cv_mu = control_variate_means
         self.ub = update_beta
         # Verify Compliant Construction
-        super(_CubQMCLDG,self).__init__(allowed_levels, allowed_distribs)
+        super(CubQMCLDG,self).__init__(allowed_levels, allowed_distribs)
 
     def integrate(self):
         """ See abstract method. """

--- a/qmcpy/stopping_criterion/_cub_qmc_ld_g.py
+++ b/qmcpy/stopping_criterion/_cub_qmc_ld_g.py
@@ -46,7 +46,7 @@ class CubQMCLDG(StoppingCriterion):
         self.cv_mu = control_variate_means
         self.ub = update_beta
         # Verify Compliant Construction
-        super(CubQMCLDG,self).__init__(allowed_levels, allowed_distribs)
+        super(CubQMCLDG,self).__init__(allowed_levels, allowed_distribs, allow_vectorized_integrals=True)
 
     def integrate(self):
         """ See abstract method. """

--- a/qmcpy/stopping_criterion/_stopping_criterion.py
+++ b/qmcpy/stopping_criterion/_stopping_criterion.py
@@ -31,8 +31,8 @@ class StoppingCriterion(object):
         if self.integrand.leveltype not in allowed_levels:
             raise ParameterError('Integrand is %s level but %s only supports %s level problems.' % \
             (self.integrand.leveltype,sname,allowed_levels))
-        if (not allow_vectorized_integrals) and self.integrand.output_dims!=1:
-            raise ParameterError('Vectorized integrals (with k>1 outputs per sample) are not supported by this stopping criterion')
+        if (not allow_vectorized_integrals) and self.integrand.dprime!=1:
+            raise ParameterError('Vectorized integrals (with dprime>1 outputs per sample) are not supported by this stopping criterion')
         # parameter checks
         if not hasattr(self,'parameters'):
             self.parameters = []

--- a/qmcpy/stopping_criterion/_stopping_criterion.py
+++ b/qmcpy/stopping_criterion/_stopping_criterion.py
@@ -6,7 +6,7 @@ from ..util import DistributionCompatibilityError, ParameterError, \
 class StoppingCriterion(object):
     """ Stopping Criterion abstract class. DO NOT INSTANTIATE. """
     
-    def __init__(self, allowed_levels, allowed_distribs):
+    def __init__(self, allowed_levels, allowed_distribs, allow_vectorized_integrals):
         """
         Args:
             distribution (DiscreteDistribution): a DiscreteDistribution
@@ -31,6 +31,8 @@ class StoppingCriterion(object):
         if self.integrand.leveltype not in allowed_levels:
             raise ParameterError('Integrand is %s level but %s only supports %s level problems.' % \
             (self.integrand.leveltype,sname,allowed_levels))
+        if (not allow_vectorized_integrals) and self.integrand.output_dims!=1:
+            raise ParameterError('Vectorized integrals (with k>1 outputs per sample) are not supported by this stopping criterion')
         # parameter checks
         if not hasattr(self,'parameters'):
             self.parameters = []

--- a/qmcpy/stopping_criterion/cub_mc_clt.py
+++ b/qmcpy/stopping_criterion/cub_mc_clt.py
@@ -20,16 +20,13 @@ class CubMCCLT(StoppingCriterion):
     >>> solution
     1.801...
     >>> data
-    Solution: 1.8010         
-    Keister (Integrand Object)
-    IIDStdUniform (DiscreteDistribution Object)
-        d               2^(1)
-        seed            7
-        mimics          StdUniform
-    Gaussian (TrueMeasure Object)
-        mean            0
-        covariance      2^(-1)
-        decomp_type     pca
+    MeanVarData (AccumulateData Object)
+        solution        1.801
+        error_bound     0.051
+        n_total         6765
+        n               5741
+        levels          1
+        time_integrate  ...
     CubMCCLT (StoppingCriterion Object)
         inflate         1.200
         alpha           0.010
@@ -37,14 +34,15 @@ class CubMCCLT(StoppingCriterion):
         rel_tol         0
         n_init          2^(10)
         n_max           10000000000
-    MeanVarData (AccumulateData Object)
-        levels          1
-        solution        1.801
-        n               5741
-        n_total         6765
-        error_bound     0.051
-        confid_int      [1.75  1.852]
-        time_integrate  ...
+    Keister (Integrand Object)
+    Gaussian (TrueMeasure Object)
+        mean            0
+        covariance      2^(-1)
+        decomp_type     pca
+    IIDStdUniform (DiscreteDistribution Object)
+        d               2^(1)
+        seed            7
+        mimics          StdUniform
     >>> ac = AsianOption(IIDStdUniform(),
     ...     multi_level_dimensions = [2,4,8])
     >>> sc = CubMCCLT(ac,abs_tol=.05)

--- a/qmcpy/stopping_criterion/cub_mc_clt.py
+++ b/qmcpy/stopping_criterion/cub_mc_clt.py
@@ -93,7 +93,8 @@ class CubMCCLT(StoppingCriterion):
         # Verify Compliant Construction
         allowed_levels = ['single','fixed-multi']
         allowed_distribs = ["IIDStdUniform","IIDStdGaussian"]
-        super(CubMCCLT,self).__init__(allowed_levels, allowed_distribs)
+        allow_vectorized_integrals = False
+        super(CubMCCLT,self).__init__(allowed_levels, allowed_distribs, allow_vectorized_integrals)
 
     def integrate(self):
         """ See abstract method. """

--- a/qmcpy/stopping_criterion/cub_mc_g.py
+++ b/qmcpy/stopping_criterion/cub_mc_g.py
@@ -22,16 +22,13 @@ class CubMCG(StoppingCriterion):
     >>> solution
     1.803...
     >>> data
-    Solution: 1.8039         
-    Keister (Integrand Object)
-    IIDStdUniform (DiscreteDistribution Object)
-        d               2^(1)
-        seed            7
-        mimics          StdUniform
-    Gaussian (TrueMeasure Object)
-        mean            0
-        covariance      2^(-1)
-        decomp_type     pca
+    MeanVarData (AccumulateData Object)
+        solution        1.804
+        error_bound     0.050
+        n_total         14497
+        n               13473
+        levels          1
+        time_integrate  ...
     CubMCG (StoppingCriterion Object)
         inflate         1.200
         alpha           0.010
@@ -39,14 +36,15 @@ class CubMCG(StoppingCriterion):
         rel_tol         0
         n_init          2^(10)
         n_max           10000000000
-    MeanVarData (AccumulateData Object)
-        levels          1
-        solution        1.804
-        n               13473
-        n_total         14497
-        error_bound     0.050
-        confid_int      [1.754 1.854]
-        time_integrate  ...
+    Keister (Integrand Object)
+    Gaussian (TrueMeasure Object)
+        mean            0
+        covariance      2^(-1)
+        decomp_type     pca
+    IIDStdUniform (DiscreteDistribution Object)
+        d               2^(1)
+        seed            7
+        mimics          StdUniform
     >>> dd = IIDStdUniform(1,seed=7)
     >>> k = Keister(dd)
     >>> cv1 = CustomFun(Uniform(dd),lambda x: sin(pi*x).sum(1))

--- a/qmcpy/stopping_criterion/cub_mc_g.py
+++ b/qmcpy/stopping_criterion/cub_mc_g.py
@@ -120,7 +120,8 @@ class CubMCG(StoppingCriterion):
         # Verify Compliant Construction
         allowed_levels = ['single']
         allowed_distribs = ["IIDStdUniform","IIDStdGaussian"]
-        super(CubMCG,self).__init__(allowed_levels, allowed_distribs)
+        allow_vectorized_integrals = False
+        super(CubMCG,self).__init__(allowed_levels, allowed_distribs, allow_vectorized_integrals)
 
     def integrate(self):
         """ See abstract method. """

--- a/qmcpy/stopping_criterion/cub_mc_ml.py
+++ b/qmcpy/stopping_criterion/cub_mc_ml.py
@@ -114,7 +114,8 @@ class CubMCML(StoppingCriterion):
         # Verify Compliant Construction
         allowed_levels = ['adaptive-multi']
         allowed_distribs = ["IIDStdUniform", "IIDStdGaussian"]
-        super(CubMCML,self).__init__(allowed_levels, allowed_distribs)
+        allow_vectorized_integrals = False
+        super(CubMCML,self).__init__(allowed_levels, allowed_distribs, allow_vectorized_integrals)
 
     def integrate(self):
         """ See abstract method. """

--- a/qmcpy/stopping_criterion/cub_mc_ml.py
+++ b/qmcpy/stopping_criterion/cub_mc_ml.py
@@ -20,7 +20,25 @@ class CubMCML(StoppingCriterion):
     >>> solution
     10.44...
     >>> data
-    Solution: 10.4450        
+    MLMCData (AccumulateData Object)
+        solution        10.445
+        n_total         1220156
+        levels          7
+        n_level         [1.174e+06 2.177e+04 9.205e+03 3.845e+03 1.295e+03 4.470e+02 1.590e+02]
+        dimensions      [ 1.  2.  4.  8. 16. 32. 64.]
+        mean_level      [1.006e+01 1.758e-01 1.046e-01 5.690e-02 3.043e-02 1.367e-02 6.812e-03]
+        var_level       [1.962e+02 1.347e-01 4.817e-02 1.279e-02 3.224e-03 8.278e-04 1.541e-04]
+        cost_per_sample [ 1.  2.  4.  8. 16. 32. 64.]
+        alpha           0.947
+        beta            1.955
+        gamma           1.000
+        time_integrate  ...
+    CubMCML (StoppingCriterion Object)
+        rmse_tol        0.019
+        n_init          2^(8)
+        levels_min      2^(1)
+        levels_max      10
+        theta           2^(-1)
     MLCallOptions (Integrand Object)
         option          european
         sigma           0.200
@@ -28,32 +46,14 @@ class CubMCML(StoppingCriterion):
         r               0.050
         t               1
         b               85
-    IIDStdUniform (DiscreteDistribution Object)
-        d               2^(6)
-        seed            7
-        mimics          StdUniform
     Gaussian (TrueMeasure Object)
         mean            0
         covariance      1
         decomp_type     pca
-    CubMCML (StoppingCriterion Object)
-        rmse_tol        0.019
-        n_init          2^(8)
-        levels_min      2^(1)
-        levels_max      10
-        theta           2^(-1)
-    MLMCData (AccumulateData Object)
-        levels          7
-        dimensions      [ 1.  2.  4.  8. 16. 32. 64.]
-        n_level         [1.174e+06 2.177e+04 9.205e+03 3.845e+03 1.295e+03 4.470e+02 1.590e+02]
-        mean_level      [1.006e+01 1.758e-01 1.046e-01 5.690e-02 3.043e-02 1.367e-02 6.812e-03]
-        var_level       [1.962e+02 1.347e-01 4.817e-02 1.279e-02 3.224e-03 8.278e-04 1.541e-04]
-        cost_per_sample [ 1.  2.  4.  8. 16. 32. 64.]
-        n_total         1220156
-        alpha           0.947
-        beta            1.955
-        gamma           1.000
-        time_integrate  ...
+    IIDStdUniform (DiscreteDistribution Object)
+        d               2^(6)
+        seed            7
+        mimics          StdUniform
 
     Original Implementation:
 

--- a/qmcpy/stopping_criterion/cub_mc_ml_cont.py
+++ b/qmcpy/stopping_criterion/cub_mc_ml_cont.py
@@ -21,22 +21,19 @@ class CubMCMLCont(StoppingCriterion):
     >>> solution
     10.427...
     >>> data
-    Solution: 10.4273        
-    MLCallOptions (Integrand Object)
-        option          european
-        sigma           0.200
-        k               100
-        r               0.050
-        t               1
-        b               85
-    IIDStdUniform (DiscreteDistribution Object)
-        d               2^(4)
-        seed            7
-        mimics          StdUniform
-    Gaussian (TrueMeasure Object)
-        mean            0
-        covariance      1
-        decomp_type     pca
+    MLMCData (AccumulateData Object)
+        solution        10.427
+        n_total         1197552
+        levels          5
+        n_level         [1.160e+06 2.245e+04 8.903e+03 5.002e+03 9.230e+02]
+        dimensions      [ 1.  2.  4.  8. 16.]
+        mean_level      [10.055  0.183  0.102  0.056  0.031]
+        var_level       [1.963e+02 1.442e-01 4.485e-02 1.139e-02 3.477e-03]
+        cost_per_sample [ 1.  2.  4.  8. 16.]
+        alpha           0.856
+        beta            1.810
+        gamma           1
+        time_integrate  ...
     CubMCMLCont (StoppingCriterion Object)
         rmse_tol        0.019
         n_init          2^(8)
@@ -46,18 +43,21 @@ class CubMCMLCont(StoppingCriterion):
         tol_mult        1.668
         theta_init      2^(-1)
         theta           0.365
-    MLMCData (AccumulateData Object)
-        levels          5
-        dimensions      [ 1.  2.  4.  8. 16.]
-        n_level         [1.160e+06 2.245e+04 8.903e+03 5.002e+03 9.230e+02]
-        mean_level      [10.055  0.183  0.102  0.056  0.031]
-        var_level       [1.963e+02 1.442e-01 4.485e-02 1.139e-02 3.477e-03]
-        cost_per_sample [ 1.  2.  4.  8. 16.]
-        n_total         1197552
-        alpha           0.856
-        beta            1.810
-        gamma           1
-        time_integrate  ...
+    MLCallOptions (Integrand Object)
+        option          european
+        sigma           0.200
+        k               100
+        r               0.050
+        t               1
+        b               85
+    Gaussian (TrueMeasure Object)
+        mean            0
+        covariance      1
+        decomp_type     pca
+    IIDStdUniform (DiscreteDistribution Object)
+        d               2^(4)
+        seed            7
+        mimics          StdUniform
 
     Original Implementation:
 

--- a/qmcpy/stopping_criterion/cub_mc_ml_cont.py
+++ b/qmcpy/stopping_criterion/cub_mc_ml_cont.py
@@ -114,7 +114,8 @@ class CubMCMLCont(StoppingCriterion):
         # Verify Compliant Construction
         allowed_levels = ['adaptive-multi']
         allowed_distribs = ["IIDStdUniform", "IIDStdGaussian"]
-        super(CubMCMLCont,self).__init__(allowed_levels, allowed_distribs)
+        allow_vectorized_integrals = False
+        super(CubMCMLCont,self).__init__(allowed_levels, allowed_distribs, allow_vectorized_integrals)
 
     def integrate(self):
         # Construct AccumulateData Object to House Integration Data

--- a/qmcpy/stopping_criterion/cub_qmc_bayes_lattice_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_bayes_lattice_g.py
@@ -22,29 +22,28 @@ class CubBayesLatticeG(StoppingCriterion):
     >>> solution
     1.808...
     >>> data
-    Solution: 1.8082         
-    Keister (Integrand Object)
-    Lattice (DiscreteDistribution Object)
-        d               2^(1)
-        randomize       1
-        order           linear
-        seed            123456789
-        mimics          StdUniform
-    Gaussian (TrueMeasure Object)
-        mean            0
-        covariance      2^(-1)
-        decomp_type     pca
+    LDTransformBayesData (AccumulateData Object)
+        solution        1.808
+        error_bound     7.37e-04
+        n_total         256
+        time_integrate  ...
     CubBayesLatticeG (StoppingCriterion Object)
         abs_tol         0.050
         rel_tol         0
         n_init          2^(8)
         n_max           2^(22)
         order           2^(1)
-    LDTransformBayesData (AccumulateData Object)
-        n_total         256
-        solution        1.808
-        error_bound     7.37e-04
-        time_integrate  ...
+    Keister (Integrand Object)
+    Gaussian (TrueMeasure Object)
+        mean            0
+        covariance      2^(-1)
+        decomp_type     pca
+    Lattice (DiscreteDistribution Object)
+        d               2^(1)
+        randomize       1
+        order           linear
+        seed            123456789
+        mimics          StdUniform
     
     Adapted from 
         https://github.com/GailGithub/GAIL_Dev/blob/master/Algorithms/IntegrationExpectation/cubBayesLattice_g.m

--- a/qmcpy/stopping_criterion/cub_qmc_bayes_lattice_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_bayes_lattice_g.py
@@ -119,7 +119,8 @@ class CubBayesLatticeG(StoppingCriterion):
         # Verify Compliant Construction
         allowed_levels = ['single']
         allowed_distribs = ["Lattice"]
-        super(CubBayesLatticeG, self).__init__(allowed_levels, allowed_distribs)
+        allow_vectorized_integrals = False
+        super(CubBayesLatticeG, self).__init__(allowed_levels, allowed_distribs, allow_vectorized_integrals)
 
         if self.discrete_distrib.randomize == False:
             raise ParameterError("CubBayesLattice_g requires discrete_distrib to have randomize=True")

--- a/qmcpy/stopping_criterion/cub_qmc_bayes_net_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_bayes_net_g.py
@@ -23,8 +23,21 @@ class CubBayesNetG(StoppingCriterion):
     >>> solution
     1.798...
     >>> data
-    Solution: 1.7986         
+    LDTransformBayesData (AccumulateData Object)
+        solution        1.799
+        error_bound     0.019
+        n_total         256
+        time_integrate  ...
+    CubBayesNetG (StoppingCriterion Object)
+        abs_tol         0.050
+        rel_tol         0
+        n_init          2^(8)
+        n_max           2^(22)
     Keister (Integrand Object)
+    Gaussian (TrueMeasure Object)
+        mean            0
+        covariance      2^(-1)
+        decomp_type     pca
     Sobol (DiscreteDistribution Object)
         d               2^(1)
         randomize       1
@@ -32,20 +45,6 @@ class CubBayesNetG(StoppingCriterion):
         seed            123456789
         mimics          StdUniform
         dim0            0
-    Gaussian (TrueMeasure Object)
-        mean            0
-        covariance      2^(-1)
-        decomp_type     pca
-    CubBayesNetG (StoppingCriterion Object)
-        abs_tol         0.050
-        rel_tol         0
-        n_init          2^(8)
-        n_max           2^(22)
-    LDTransformBayesData (AccumulateData Object)
-        n_total         256
-        solution        1.799
-        error_bound     0.019
-        time_integrate  ...
         
     Adapted from
         https://github.com/GailGithub/GAIL_Dev/blob/master/Algorithms/IntegrationExpectation/cubBayesNet_g.m

--- a/qmcpy/stopping_criterion/cub_qmc_bayes_net_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_bayes_net_g.py
@@ -121,7 +121,8 @@ class CubBayesNetG(StoppingCriterion):
         # Verify Compliant Construction
         allowed_levels = ['single']
         allowed_distribs = ["Sobol"]
-        super(CubBayesNetG, self).__init__(allowed_levels, allowed_distribs)
+        allow_vectorized_integrals = False
+        super(CubBayesNetG, self).__init__(allowed_levels, allowed_distribs, allow_vectorized_integrals)
 
         if self.discrete_distrib.randomize == False:
             raise ParameterError("CubBayesNet_g requires discrete_distrib to have randomize=True")

--- a/qmcpy/stopping_criterion/cub_qmc_clt.py
+++ b/qmcpy/stopping_criterion/cub_qmc_clt.py
@@ -23,13 +23,10 @@ class CubQMCCLT(StoppingCriterion):
     >>> data
     MeanVarDataRep (AccumulateData Object)
         solution        1.380
-        replications    2^(4)
-        sighat          6.25e-04
-        n               2^(8)
-        n_total         2^(12)
         error_bound     4.83e-04
-        confid_int      [[1.38 ]
-                        [1.381]]
+        n_total         2^(12)
+        n               2^(8)
+        replications    2^(4)
         time_integrate  ...
     CubQMCCLT (StoppingCriterion Object)
         inflate         1.200
@@ -53,17 +50,14 @@ class CubQMCCLT(StoppingCriterion):
     >>> sc = CubQMCCLT(f, abs_tol=1e-4)
     >>> solution,data = sc.integrate()
     >>> solution
-    array([0.4  , 0.333])
+    array([0.40000769, 0.33334103])
     >>> data
     MeanVarDataRep (AccumulateData Object)
         solution        [0.4   0.333]
-        replications    2^(4)
-        sighat          [7.984e-05 7.984e-05]
-        n               [4096. 4096.]
-        n_total         2^(16)
         error_bound     [6.17e-05 6.17e-05]
-        confid_int      [[0.4   0.333]
-                        [0.4   0.333]]
+        n_total         2^(16)
+        n               [4096. 4096.]
+        replications    2^(4)
         time_integrate  ...
     CubQMCCLT (StoppingCriterion Object)
         inflate         1.200

--- a/qmcpy/stopping_criterion/cub_qmc_clt.py
+++ b/qmcpy/stopping_criterion/cub_qmc_clt.py
@@ -19,20 +19,18 @@ class CubQMCCLT(StoppingCriterion):
     >>> sc = CubQMCCLT(k,abs_tol=.05)
     >>> solution,data = sc.integrate()
     >>> solution
-    1.380...
+    array([1.38049475])
     >>> data
-    Solution: 1.3805         
-    Keister (Integrand Object)
-    Lattice (DiscreteDistribution Object)
-        d               1
-        randomize       1
-        order           natural
-        seed            15417
-        mimics          StdUniform
-    Gaussian (TrueMeasure Object)
-        mean            0
-        covariance      2^(-1)
-        decomp_type     pca
+    MeanVarDataRep (AccumulateData Object)
+        solution        1.380
+        replications    2^(4)
+        sighat          6.25e-04
+        n               2^(8)
+        n_total         2^(12)
+        error_bound     4.83e-04
+        confid_int      [[1.38 ]
+                        [1.381]]
+        time_integrate  ...
     CubQMCCLT (StoppingCriterion Object)
         inflate         1.200
         alpha           0.010
@@ -40,19 +38,50 @@ class CubQMCCLT(StoppingCriterion):
         rel_tol         0
         n_init          2^(8)
         n_max           2^(30)
-    MeanVarDataRep (AccumulateData Object)
-        replications    2^(4)
-        solution        1.380
-        sighat          6.25e-04
-        n_total         2^(12)
-        error_bound     4.83e-04
-        confid_int      [1.38  1.381]
-        time_integrate  ...
-    >>> f = XtoVectorizedPowers(Sobol(2,seed=7), powers=[4,5])
+    Keister (Integrand Object)
+    Gaussian (TrueMeasure Object)
+        mean            0
+        covariance      2^(-1)
+        decomp_type     pca
+    Lattice (DiscreteDistribution Object)
+        d               1
+        randomize       1
+        order           natural
+        seed            7
+        mimics          StdUniform
+    >>> f = XtoVectorizedPowers(Lattice(2,seed=7), powers=[4,5])
     >>> sc = CubQMCCLT(f, abs_tol=1e-4)
     >>> solution,data = sc.integrate()
     >>> solution
+    array([0.4  , 0.333])
     >>> data
+    MeanVarDataRep (AccumulateData Object)
+        solution        [0.4   0.333]
+        replications    2^(4)
+        sighat          [7.984e-05 7.984e-05]
+        n               [4096. 4096.]
+        n_total         2^(16)
+        error_bound     [6.17e-05 6.17e-05]
+        confid_int      [[0.4   0.333]
+                        [0.4   0.333]]
+        time_integrate  ...
+    CubQMCCLT (StoppingCriterion Object)
+        inflate         1.200
+        alpha           0.010
+        abs_tol         1.00e-04
+        rel_tol         0
+        n_init          2^(8)
+        n_max           2^(30)
+    XtoVectorizedPowers (Integrand Object)
+    Uniform (TrueMeasure Object)
+        lower_bound     0
+        upper_bound     1
+    Lattice (DiscreteDistribution Object)
+        d               2^(1)
+        randomize       1
+        order           natural
+        seed            7
+        mimics          StdUniform
 
     """
 
@@ -120,8 +149,8 @@ class CubQMCCLT(StoppingCriterion):
                 break
             else:
                 # double sample size
-                self.data.n_r_prev = where(self.data.compute_flags,self.data.n_r,self.data.n_r_prev)
-                self.data.n_r = where(self.data.compute_flags,2*self.data.n_r,self.data.n_r)
+                self.data.nprev = where(self.data.compute_flags,self.data.n,self.data.nprev)
+                self.data.n = where(self.data.compute_flags,2*self.data.n,self.data.n)
         # CLT confidence interval
         self.data.confid_int = self.data.solution +  self.data.error_bound * array([[-1.],[1.]])
         self.data.time_integrate = time() - t_start

--- a/qmcpy/stopping_criterion/cub_qmc_clt.py
+++ b/qmcpy/stopping_criterion/cub_qmc_clt.py
@@ -97,8 +97,9 @@ class CubQMCCLT(StoppingCriterion):
         while True:
             self.data.update_data()
             self.data.error_bound = self.z_star * self.inflate * self.data.sighat / sqrt(self.data.replications)
-            tol_up = max(self.abs_tol, abs(self.data.solution) * self.rel_tol)
-            if self.data.error_bound < tol_up:
+            tol_up = maximum(self.abs_tol, abs(self.data.solution) * self.rel_tol)
+            self.data.compute_flags = self.data.error_bound > tol_up
+            if sum(self.data.compute_flags)==0:
                 # sufficiently estimated
                 break
             elif 2 * self.data.n_total > self.n_max:
@@ -115,7 +116,7 @@ class CubQMCCLT(StoppingCriterion):
                 # double sample size
                 self.data.n_r *= 2
         # CLT confidence interval
-        self.data.confid_int = self.data.solution +  self.data.error_bound * array([-1., 1.])
+        self.data.confid_int = self.data.solution +  self.data.error_bound * array([[-1.],[1.]])
         self.data.time_integrate = time() - t_start
         return self.data.solution, self.data
     

--- a/qmcpy/stopping_criterion/cub_qmc_clt.py
+++ b/qmcpy/stopping_criterion/cub_qmc_clt.py
@@ -84,7 +84,8 @@ class CubQMCCLT(StoppingCriterion):
         # Verify Compliant Construction
         allowed_levels = ["single"]
         allowed_distribs = ["Lattice", "Sobol","Halton"]
-        super(CubQMCCLT,self).__init__(allowed_levels, allowed_distribs)
+        allow_vectorized_integrals = True
+        super(CubQMCCLT,self).__init__(allowed_levels, allowed_distribs, allow_vectorized_integrals)
         if not self.discrete_distrib.randomize:
             raise ParameterError("CLTRep requires distribution to have randomize=True")
          

--- a/qmcpy/stopping_criterion/cub_qmc_lattice_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_lattice_g.py
@@ -18,28 +18,27 @@ class CubQMCLatticeG(CubQMCLDG):
     >>> solution
     1.806...
     >>> data
-    Solution: 1.8068         
+    LDTransformData (AccumulateData Object)
+        solution        1.807
+        error_bound     0.005
+        n_total         2^(10)
+        time_integrate  ...
+    CubQMCLatticeG (StoppingCriterion Object)
+        abs_tol         0.050
+        rel_tol         0
+        n_init          2^(10)
+        n_max           2^(35)
     Keister (Integrand Object)
+    Gaussian (TrueMeasure Object)
+        mean            0
+        covariance      2^(-1)
+        decomp_type     pca
     Lattice (DiscreteDistribution Object)
         d               2^(1)
         randomize       1
         order           natural
         seed            7
         mimics          StdUniform
-    Gaussian (TrueMeasure Object)
-        mean            0
-        covariance      2^(-1)
-        decomp_type     pca
-    CubQMCLatticeG (StoppingCriterion Object)
-        abs_tol         0.050
-        rel_tol         0
-        n_init          2^(10)
-        n_max           2^(35)
-    LDTransformData (AccumulateData Object)
-        n_total         2^(10)
-        solution        1.807
-        error_bound     0.005
-        time_integrate  ...
     
     Original Implementation:
 

--- a/qmcpy/stopping_criterion/cub_qmc_lattice_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_lattice_g.py
@@ -1,15 +1,12 @@
-from ._stopping_criterion import StoppingCriterion
-from ..accumulate_data import LDTransformData
+from ._cub_qmc_ld_g import _CubQMCLDG
 from ..discrete_distribution import Lattice
 from ..true_measure import Gaussian
 from ..integrand import Keister
-from ..util import MaxSamplesWarning, ParameterError, ParameterWarning
+from ..util import ParameterError
 from numpy import *
-from time import time
-import warnings
 
 
-class CubQMCLatticeG(StoppingCriterion):
+class CubQMCLatticeG(_CubQMCLDG):
     """
     Stopping Criterion quasi-Monte Carlo method using rank-1 Lattices cubature over
     a d-dimensional region to integrate within a specified generalized error
@@ -76,7 +73,7 @@ class CubQMCLatticeG(StoppingCriterion):
     """
 
     def __init__(self, integrand, abs_tol=1e-2, rel_tol=0., n_init=2.**10, n_max=2.**35,
-                 fudge=lambda m: 5.*2.**(-m), check_cone=False, ptransform='Baker'):
+        fudge=lambda m: 5.*2.**(-m), check_cone=False, ptransform='Baker'):
         """
         Args:
             integrand (Integrand): an instance of Integrand
@@ -89,83 +86,16 @@ class CubQMCLatticeG(StoppingCriterion):
                               in the cone of functions
             check_cone (boolean): check if the function falls in the cone
         """
-        self.parameters = ['abs_tol','rel_tol','n_init','n_max']
-        # Input Checks
-        self.abs_tol = float(abs_tol)
-        self.rel_tol = float(rel_tol)
-        m_min = log2(n_init)
-        m_max = log2(n_max)
-        if m_min%1 != 0. or m_min < 8 or m_max%1 != 0:
-            warning_s = '''
-                n_init and n_max must be a powers of 2.
-                n_init must be >= 2^8.
-                Using n_init = 2^10 and n_max=2^35.'''
-            warnings.warn(warning_s, ParameterWarning)
-            m_min = 10.
-            m_max = 35.
-        self.n_init = 2.**m_min
-        self.n_max = 2.**m_max
-        self.integrand = integrand
-        self.m_min = m_min
-        self.m_max = m_max
-        self.fudge = fudge
-        self.check_cone = check_cone
-        self.ptransform = ptransform
-        self.coefv = lambda nl: exp(-2*pi*1j*arange(nl)/(2*nl))
-        # QMCPy Objs
-        self.integrand = integrand
-        self.true_measure = self.integrand.true_measure
-        self.discrete_distrib = self.integrand.discrete_distrib
-        # Verify Compliant Construction
-        allowed_levels = ['single']
-        allowed_distribs = ["Lattice"]
-        super(CubQMCLatticeG,self).__init__(allowed_levels, allowed_distribs)
+        super(CubQMCLatticeG,self).__init__(integrand,abs_tol,rel_tol,n_init,n_max,fudge,check_cone,
+            control_variates = [],
+            control_variate_means = [],
+            update_beta=False,
+            ptransform = ptransform,
+            coefv = lambda nl: exp(-2*pi*1j*arange(nl)/(2*nl)), 
+            allowed_levels = ['single'],
+            allowed_distribs = ["Lattice"],
+            cast_complex = True)
         if not self.discrete_distrib.randomize:
             raise ParameterError("CubLattice_g requires distribution to have randomize=True")
         if self.discrete_distrib.order != 'natural':
             raise ParameterError("CubLattice_g requires Lattice with 'natural' order")
-        
-    def integrate(self):
-        """ See abstract method. """
-        # Construct AccumulateData Object to House Integration data
-        self.data = LDTransformData(self, self.integrand, self.true_measure, self.discrete_distrib,
-            self.coefv, self.m_min, self.m_max, self.fudge, self.check_cone, self.ptransform, True, # need to cast as complex
-            [], [], False) # currently not compatible with control variates
-        t_start = time()
-        while True:
-            self.data.update_data()
-            # Check the end of the algorithm
-            self.data.error_bound = self.data.fudge(self.data.m)*self.data.stilde
-            # Compute optimal estimator
-            ub = max(self.abs_tol, self.rel_tol*abs(self.data.solution + self.data.error_bound))
-            lb = max(self.abs_tol, self.rel_tol*abs(self.data.solution - self.data.error_bound))
-            self.data.solution = self.data.solution - self.data.error_bound*(ub-lb) / (ub+lb)
-            if 4.*self.data.error_bound**2/(ub+lb)**2 <= 1.:
-                # stopping criterion met
-                break
-            elif self.data.m == self.data.m_max:
-                # doubling samples would go over n_max
-                warning_s = """
-                Alread generated %d samples.
-                Trying to generate %d new samples would exceed n_max = %d.
-                No more samples will be generated.
-                Note that error tolerances may no longer be satisfied""" \
-                % (int(2.**self.data.m), int(2**self.data.m), int(2.**self.data.m_max))
-                warnings.warn(warning_s, MaxSamplesWarning)
-                break
-            else:
-                # double sample size
-                self.data.m += 1.
-        self.data.time_integrate = time() - t_start
-        return self.data.solution, self.data
-    
-    def set_tolerance(self, abs_tol=None, rel_tol=None):
-        """
-        See abstract method. 
-        
-        Args:
-            abs_tol (float): absolute tolerance. Reset if supplied, ignored if not. 
-            rel_tol (float): relative tolerance. Reset if supplied, ignored if not. 
-        """
-        if abs_tol != None: self.abs_tol = abs_tol
-        if rel_tol != None: self.rel_tol = rel_tol

--- a/qmcpy/stopping_criterion/cub_qmc_lattice_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_lattice_g.py
@@ -1,4 +1,4 @@
-from ._cub_qmc_ld_g import _CubQMCLDG
+from ._cub_qmc_ld_g import CubQMCLDG
 from ..discrete_distribution import Lattice
 from ..true_measure import Gaussian
 from ..integrand import Keister
@@ -6,7 +6,7 @@ from ..util import ParameterError
 from numpy import *
 
 
-class CubQMCLatticeG(_CubQMCLDG):
+class CubQMCLatticeG(CubQMCLDG):
     """
     Stopping Criterion quasi-Monte Carlo method using rank-1 Lattices cubature over
     a d-dimensional region to integrate within a specified generalized error

--- a/qmcpy/stopping_criterion/cub_qmc_ml.py
+++ b/qmcpy/stopping_criterion/cub_qmc_ml.py
@@ -94,7 +94,8 @@ class CubQMCML(StoppingCriterion):
         # Verify Compliant Construction
         allowed_levels = ['adaptive-multi']
         allowed_distribs = ["Lattice", "Sobol", "Halton"]
-        super(CubQMCML,self).__init__(allowed_levels, allowed_distribs)
+        allow_vectorized_integrals = False
+        super(CubQMCML,self).__init__(allowed_levels, allowed_distribs, allow_vectorized_integrals)
 
     def integrate(self):
         """ See abstract method. """

--- a/qmcpy/stopping_criterion/cub_qmc_ml.py
+++ b/qmcpy/stopping_criterion/cub_qmc_ml.py
@@ -20,7 +20,21 @@ class CubQMCML(StoppingCriterion):
     >>> solution
     10.422...
     >>> data
-    Solution: 10.4229        
+    MLQMCData (AccumulateData Object)
+        solution        10.423
+        n_total         294912
+        n_level         [8192.  256.  256.  256.  256.]
+        levels          5
+        dimensions      [ 1.  2.  4.  8. 16.]
+        mean_level      [10.054  0.184  0.102  0.055  0.027]
+        var_level       [1.617e-05 6.794e-05 2.603e-05 8.925e-06 3.123e-06]
+        bias_estimate   0.014
+        time_integrate  ...
+    CubQMCML (StoppingCriterion Object)
+        rmse_tol        0.019
+        n_init          2^(8)
+        n_max           10000000000
+        replications    2^(5)
     MLCallOptions (Integrand Object)
         option          european
         sigma           0.200
@@ -28,30 +42,16 @@ class CubQMCML(StoppingCriterion):
         r               0.050
         t               1
         b               85
+    Gaussian (TrueMeasure Object)
+        mean            0
+        covariance      1
+        decomp_type     pca
     Lattice (DiscreteDistribution Object)
         d               2^(4)
         randomize       1
         order           natural
         seed            733837
         mimics          StdUniform
-    Gaussian (TrueMeasure Object)
-        mean            0
-        covariance      1
-        decomp_type     pca
-    CubQMCML (StoppingCriterion Object)
-        rmse_tol        0.019
-        n_init          2^(8)
-        n_max           10000000000
-        replications    2^(5)
-    MLQMCData (AccumulateData Object)
-        levels          5
-        dimensions      [ 1.  2.  4.  8. 16.]
-        n_level         [8192.  256.  256.  256.  256.]
-        mean_level      [10.054  0.184  0.102  0.055  0.027]
-        var_level       [1.617e-05 6.794e-05 2.603e-05 8.925e-06 3.123e-06]
-        bias_estimate   0.014
-        n_total         294912
-        time_integrate  ...
     
     References:
         

--- a/qmcpy/stopping_criterion/cub_qmc_ml_cont.py
+++ b/qmcpy/stopping_criterion/cub_qmc_ml_cont.py
@@ -110,7 +110,8 @@ class CubQMCMLCont(StoppingCriterion):
         # Verify Compliant Construction
         allowed_levels = ['adaptive-multi']
         allowed_distribs = ["Lattice", "Sobol","Halton"]
-        super(CubQMCMLCont,self).__init__(allowed_levels, allowed_distribs)
+        allow_vectorized_integrals = False
+        super(CubQMCMLCont,self).__init__(allowed_levels, allowed_distribs, allow_vectorized_integrals)
 
     def integrate(self):
         # Construct AccumulateData Object to House Integration Data

--- a/qmcpy/stopping_criterion/cub_qmc_ml_cont.py
+++ b/qmcpy/stopping_criterion/cub_qmc_ml_cont.py
@@ -21,24 +21,16 @@ class CubQMCMLCont(StoppingCriterion):
     >>> solution
     10.394...
     >>> data
-    Solution: 10.3948        
-    MLCallOptions (Integrand Object)
-        option          european
-        sigma           0.200
-        k               100
-        r               0.050
-        t               1
-        b               85
-    Lattice (DiscreteDistribution Object)
-        d               1
-        randomize       1
-        order           natural
-        seed            561339
-        mimics          StdUniform
-    Gaussian (TrueMeasure Object)
-        mean            0
-        covariance      1
-        decomp_type     pca
+    MLQMCData (AccumulateData Object)
+        solution        10.395
+        n_total         155648
+        n_level         [4096.  256.  256.  256.]
+        levels          2^(2)
+        dimensions      [1. 2. 4. 8.]
+        mean_level      [10.053  0.184  0.102  0.055]
+        var_level       [8.703e-05 6.794e-05 2.603e-05 8.925e-06]
+        bias_estimate   0.035
+        time_integrate  ...
     CubQMCMLCont (StoppingCriterion Object)
         rmse_tol        0.019
         n_init          2^(8)
@@ -50,15 +42,23 @@ class CubQMCMLCont(StoppingCriterion):
         tol_mult        1.668
         theta_init      2^(-1)
         theta           2^(-3)
-    MLQMCData (AccumulateData Object)
-        levels          2^(2)
-        dimensions      [1. 2. 4. 8.]
-        n_level         [4096.  256.  256.  256.]
-        mean_level      [10.053  0.184  0.102  0.055]
-        var_level       [8.703e-05 6.794e-05 2.603e-05 8.925e-06]
-        bias_estimate   0.035
-        n_total         155648
-        time_integrate  ...
+    MLCallOptions (Integrand Object)
+        option          european
+        sigma           0.200
+        k               100
+        r               0.050
+        t               1
+        b               85
+    Gaussian (TrueMeasure Object)
+        mean            0
+        covariance      1
+        decomp_type     pca
+    Lattice (DiscreteDistribution Object)
+        d               1
+        randomize       1
+        order           natural
+        seed            561339
+        mimics          StdUniform
     
     References:
         

--- a/qmcpy/stopping_criterion/cub_qmc_sobol_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_sobol_g.py
@@ -18,8 +18,21 @@ class CubQMCSobolG(CubQMCLDG):
     >>> solution
     1.807...
     >>> data
-    Solution: 1.8079         
+    LDTransformData (AccumulateData Object)
+        solution        1.808
+        error_bound     0.005
+        n_total         2^(10)
+        time_integrate  ...
+    CubQMCSobolG (StoppingCriterion Object)
+        abs_tol         0.050
+        rel_tol         0
+        n_init          2^(10)
+        n_max           2^(35)
     Keister (Integrand Object)
+    Gaussian (TrueMeasure Object)
+        mean            0
+        covariance      2^(-1)
+        decomp_type     pca
     Sobol (DiscreteDistribution Object)
         d               2^(1)
         randomize       1
@@ -27,20 +40,6 @@ class CubQMCSobolG(CubQMCLDG):
         seed            7
         mimics          StdUniform
         dim0            0
-    Gaussian (TrueMeasure Object)
-        mean            0
-        covariance      2^(-1)
-        decomp_type     pca
-    CubQMCSobolG (StoppingCriterion Object)
-        abs_tol         0.050
-        rel_tol         0
-        n_init          2^(10)
-        n_max           2^(35)
-    LDTransformData (AccumulateData Object)
-        n_total         2^(10)
-        solution        1.808
-        error_bound     0.005
-        time_integrate  ...
     >>> dd = Sobol(3,seed=7)
     >>> g1 = CustomFun(Uniform(dd,0,2),lambda t: 10*t[:,0]-5*t[:,1]**2+t[:,2]**3)
     >>> cv1 = CustomFun(Uniform(dd,0,2),lambda t: t[:,0])

--- a/qmcpy/stopping_criterion/cub_qmc_sobol_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_sobol_g.py
@@ -1,15 +1,12 @@
-from ._stopping_criterion import StoppingCriterion
-from ..accumulate_data import LDTransformData
-from ..util import MaxSamplesWarning, ParameterError, ParameterWarning
+from ._cub_qmc_ld_g import _CubQMCLDG
+from ..util import ParameterError
 from ..discrete_distribution import Sobol
 from ..true_measure import Gaussian, Uniform
 from ..integrand import Keister, CustomFun
 from numpy import *
-from time import time
-import warnings
 
 
-class CubQMCSobolG(StoppingCriterion):
+class CubQMCSobolG(_CubQMCLDG):
     """
     Quasi-Monte Carlo method using Sobol' cubature over the
     d-dimensional region to integrate within a specified generalized error
@@ -107,84 +104,14 @@ class CubQMCSobolG(StoppingCriterion):
             control_variate_means (list): list of means for each control variate
             update_beta (bool): update control variate beta coefficients at each iteration? 
         """
-        self.parameters = ['abs_tol','rel_tol','n_init','n_max']
-        # Input Checks
-        self.abs_tol = float(abs_tol)
-        self.rel_tol = float(rel_tol)
-        m_min = log2(n_init)
-        m_max = log2(n_max)
-        if m_min%1 != 0. or m_min < 8. or m_max%1 != 0.:
-            warning_s = '''
-                n_init and n_max must be a powers of 2.
-                n_init must be >= 2^8.
-                Using n_init = 2^10 and n_max=2^35.'''
-            warnings.warn(warning_s, ParameterWarning)
-            m_min = 10.
-            m_max = 35.
-        self.n_init = 2.**m_min
-        self.n_max = 2.**m_max
-        self.m_min = m_min
-        self.m_max = m_max
-        self.fudge = fudge
-        self.check_cone = check_cone
-        self.coefv = lambda nl: ones(nl,dtype=float)
-        # QMCPy Objs
-        self.integrand = integrand
-        self.true_measure = self.integrand.true_measure
-        self.discrete_distrib = self.integrand.discrete_distrib
-        self.cv = control_variates
-        self.cv_mu = control_variate_means
-        self.ub = update_beta
-        # Verify Compliant Construction
-        allowed_levels = ['single']
-        allowed_distribs = ["Sobol"]
-        super(CubQMCSobolG,self).__init__(allowed_levels, allowed_distribs)
+        super(CubQMCSobolG,self).__init__(integrand,abs_tol,rel_tol,n_init,n_max,fudge,
+            check_cone,control_variates,control_variate_means,update_beta,
+            ptransform = 'none',
+            coefv = lambda nl: ones(nl,dtype=float), 
+            allowed_levels = ['single'],
+            allowed_distribs = ["Sobol"],
+            cast_complex = False)
         if (not self.discrete_distrib.randomize) or self.discrete_distrib.graycode:
             raise ParameterError("CubSobol_g requires distribution to have randomize=True and graycode=False. Use QRNG backend.")
-
-    def integrate(self):
-        """ See abstract method. """
-        # Construct AccumulateData Object to House Integration data
-        self.data = LDTransformData(self, self.integrand, self.true_measure, self.discrete_distrib,
-            self.coefv, self.m_min, self.m_max, self.fudge, self.check_cone, ptransform='none', cast_complex=False,
-            control_variates=self.cv, control_variate_means=self.cv_mu, update_beta=self.ub)
-        t_start = time()
-        while True:
-            self.data.update_data()
-            # Check the end of the algorithm
-            self.data.error_bound = self.data.fudge(self.data.m)*self.data.stilde
-            # Compute optimal estimator
-            ub = max(self.abs_tol, self.rel_tol*abs(self.data.solution + self.data.error_bound))
-            lb = max(self.abs_tol, self.rel_tol*abs(self.data.solution - self.data.error_bound))
-            self.data.solution = self.data.solution - self.data.error_bound*(ub-lb) / (ub+lb)
-            if 4*self.data.error_bound**2./(ub+lb)**2. <= 1.:
-                # stopping criterion met
-                break
-            elif self.data.m == self.data.m_max:
-                # doubling samples would go over n_max
-                warning_s = """
-                Alread generated %d samples.
-                Trying to generate %d new samples would exceed n_max = %d.
-                No more samples will be generated.
-                Note that error tolerances may no longer be satisfied""" \
-                % (int(2**self.data.m), int(2**self.data.m), int(2**self.data.m_max))
-                warnings.warn(warning_s, MaxSamplesWarning)
-                break
-            else:
-                # double sample size
-                self.data.m += 1.
-        self.data.time_integrate = time() - t_start
-        return self.data.solution, self.data
-    
-    def set_tolerance(self, abs_tol=None, rel_tol=None):
-        """
-        See abstract method. 
-        
-        Args:
-            abs_tol (float): absolute tolerance. Reset if supplied, ignored if not. 
-            rel_tol (float): relative tolerance. Reset if supplied, ignored if not. 
-        """
-        if abs_tol != None: self.abs_tol = abs_tol
-        if rel_tol != None: self.rel_tol = rel_tol
 
 CubQMCNetG = CubQMCSobolG

--- a/qmcpy/stopping_criterion/cub_qmc_sobol_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_sobol_g.py
@@ -112,6 +112,6 @@ class CubQMCSobolG(CubQMCLDG):
             allowed_distribs = ["Sobol"],
             cast_complex = False)
         if (not self.discrete_distrib.randomize) or self.discrete_distrib.graycode:
-            raise ParameterError("CubSobol_g requires distribution to have randomize=True and graycode=False. Use QRNG backend.")
+            raise ParameterError("CubSobol_g requires distribution to have randomize=True and graycode=False.")
 
 CubQMCNetG = CubQMCSobolG

--- a/qmcpy/stopping_criterion/cub_qmc_sobol_g.py
+++ b/qmcpy/stopping_criterion/cub_qmc_sobol_g.py
@@ -1,4 +1,4 @@
-from ._cub_qmc_ld_g import _CubQMCLDG
+from ._cub_qmc_ld_g import CubQMCLDG
 from ..util import ParameterError
 from ..discrete_distribution import Sobol
 from ..true_measure import Gaussian, Uniform
@@ -6,7 +6,7 @@ from ..integrand import Keister, CustomFun
 from numpy import *
 
 
-class CubQMCSobolG(_CubQMCLDG):
+class CubQMCSobolG(CubQMCLDG):
     """
     Quasi-Monte Carlo method using Sobol' cubature over the
     d-dimensional region to integrate within a specified generalized error

--- a/qmcpy/true_measure/brownian_motion.py
+++ b/qmcpy/true_measure/brownian_motion.py
@@ -12,8 +12,8 @@ class BrownianMotion(Gaussian):
     
     >>> bm = BrownianMotion(Sobol(4,seed=7),t_final=2,drift=2)
     >>> bm.gen_samples(2)
-    array([[0.974, 2.288, 2.866, 4.49 ],
-           [0.587, 0.745, 1.999, 2.173]])
+    array([[0.97425339, 2.28754915, 2.86639309, 4.48974531],
+           [0.58652207, 0.74524939, 1.99924858, 2.17307838]])
     >>> bm
     BrownianMotion (TrueMeasure Object)
         time_vec        [0.5 1.  1.5 2. ]

--- a/qmcpy/true_measure/gaussian.py
+++ b/qmcpy/true_measure/gaussian.py
@@ -14,10 +14,10 @@ class Gaussian(TrueMeasure):
     
     >>> g = Gaussian(Sobol(2,seed=7),mean=[1,2],covariance=[[9,4],[4,5]])
     >>> g.gen_samples(4)
-    array([[ 1.356,  2.568],
-           [-2.301, -0.282],
-           [ 8.211,  2.946],
-           [-0.381,  3.591]])
+    array([[ 1.35634625,  2.56809509],
+           [-2.30096376, -0.28228758],
+           [ 8.21131804,  2.94566957],
+           [-0.38123886,  3.59148049]])
     >>> g
     Gaussian (TrueMeasure Object)
         mean            [1 2]

--- a/qmcpy/true_measure/uniform.py
+++ b/qmcpy/true_measure/uniform.py
@@ -9,10 +9,10 @@ class Uniform(TrueMeasure):
     """
     >>> u = Uniform(Sobol(2,seed=7),lower_bound=[0,.5],upper_bound=[2,3])
     >>> u.gen_samples(4)
-    array([[0.859, 1.565],
-           [1.763, 1.879],
-           [0.05 , 2.925],
-           [1.08 , 0.739]])
+    array([[0.858979  , 1.56544372],
+           [1.76330223, 1.87886903],
+           [0.05024285, 2.92462018],
+           [1.07955154, 0.73850326]])
     >>> u
     Uniform (TrueMeasure Object)
         lower_bound     [0.  0.5]

--- a/qmcpy/util/abstraction_functions.py
+++ b/qmcpy/util/abstraction_functions.py
@@ -21,42 +21,42 @@ def _univ_repr(qmc_object, abc_class_name, attributes):
         print(qmc_object) is equivalent to print(qmc_object.__repr__()). 
         See an abstract classes __repr__ method for example call to this method. 
     """
-    np.set_printoptions(precision=3,threshold=10)
-    unique_attributes = []
-    for attrib in attributes:
-        if attrib not in unique_attributes:
-            unique_attributes += [attrib]
-    string = "%s (%s Object)" % (type(qmc_object).__name__, abc_class_name)
-    for key in unique_attributes:
-        val = getattr(qmc_object, key)
-        # list of one value becomes just that value
-        if isinstance(val, list) and len(val) == 1:
-            val = val[0]
-        elif isinstance(val, list):
-            val = array(val)
-        elif isinstance(val, ndarray):
-            if val.shape == ():
-                val = val.item()
-            elif val.size == 1:
-                val = val[0].item()
-        # printing options
-        s = '    %-15s '%key
-        if isinstance(val, int) or isinstance(val,float): # scalar
-            try:
-                warnings.filterwarnings("error")
-                p = log2(val)
-            except:
-                p = .1
-            if (p%1==0) and p!=0: # power of 2
-                s += '2^(%d)' % int(p)
-            elif isinstance(val, int) or (val%1==0): # int
-                s += '%d' % int(val)
-            else: # float 
-                if abs(val) < .001: # exponential format
-                    s += '%.2e' % val
-                else: # float format
-                    s += '%.3f' % val
-        else:
-            s += '%s' % val
-        string += '\n' + s.replace('\n', '\n    %-15s' % ' ')
+    with np.printoptions(precision=3,threshold=10):
+        unique_attributes = []
+        for attrib in attributes:
+            if attrib not in unique_attributes:
+                unique_attributes += [attrib]
+        string = "%s (%s Object)" % (type(qmc_object).__name__, abc_class_name)
+        for key in unique_attributes:
+            val = getattr(qmc_object, key)
+            # list of one value becomes just that value
+            if isinstance(val, list) and len(val) == 1:
+                val = val[0]
+            elif isinstance(val, list):
+                val = array(val)
+            elif isinstance(val, ndarray):
+                if val.shape == ():
+                    val = val.item()
+                elif val.size == 1:
+                    val = val[0].item()
+            # printing options
+            s = '    %-15s '%key
+            if isinstance(val, int) or isinstance(val,float): # scalar
+                try:
+                    warnings.filterwarnings("error")
+                    p = log2(val)
+                except:
+                    p = .1
+                if (p%1==0) and p!=0: # power of 2
+                    s += '2^(%d)' % int(p)
+                elif isinstance(val, int) or (val%1==0): # int
+                    s += '%d' % int(val)
+                else: # float 
+                    if abs(val) < .001: # exponential format
+                        s += '%.2e' % val
+                    else: # float format
+                        s += '%.3f' % val
+            else:
+                s += '%s' % val
+            string += '\n' + s.replace('\n', '\n    %-15s' % ' ')
     return string

--- a/qmcpy/util/abstraction_functions.py
+++ b/qmcpy/util/abstraction_functions.py
@@ -2,7 +2,6 @@
 
 from numpy import array, ndarray, log2
 import numpy as np
-np.set_printoptions(precision=3,threshold=10)
 import warnings
 
 
@@ -22,6 +21,7 @@ def _univ_repr(qmc_object, abc_class_name, attributes):
         print(qmc_object) is equivalent to print(qmc_object.__repr__()). 
         See an abstract classes __repr__ method for example call to this method. 
     """
+    np.set_printoptions(precision=3,threshold=10)
     unique_attributes = []
     for attrib in attributes:
         if attrib not in unique_attributes:

--- a/test/fasttests/test_integrands.py
+++ b/test/fasttests/test_integrands.py
@@ -10,10 +10,10 @@ class TestAsianOption(unittest.TestCase):
         ao = AsianOption(Sobol(2))
         x = ao.discrete_distrib.gen_samples(2**2)
         y = ao.f(x)
-        self.assertTrue(y.shape==(4,))
+        self.assertTrue(y.shape==(4,1))
         for ptransform in ['Baker','C0','C1','C1sin','C2sin','C3sin','None']:
             yp = ao.f_periodized(x,ptransform=ptransform)
-            self.assertTrue(yp.shape==(4,))
+            self.assertTrue(yp.shape==(4,1))
 
     def test__dim_at_level(self):
         ao = AsianOption(Sobol(), multi_level_dimensions=[4,8])
@@ -29,7 +29,7 @@ class TestEuropeanOption(unittest.TestCase):
             eo = EuropeanOption(Sobol(2),call_put=option_type)
             x = eo.discrete_distrib.gen_samples(4)
             y = eo.f(x)
-            self.assertTrue(y.shape==(4,))
+            self.assertTrue(y.shape==(4,1))
             eo.get_exact_value()
 
 
@@ -40,9 +40,9 @@ class TestKeister(unittest.TestCase):
         k = Keister(Gaussian(Lattice(2),mean=1,covariance=3))
         x = k.discrete_distrib.gen_samples(2**2)
         y = k.f(x)
-        self.assertTrue(y.shape==(4,))
+        self.assertTrue(y.shape==(4,1))
         y2 = k.f(x)
-        self.assertTrue(y2.shape==(4,))
+        self.assertTrue(y2.shape==(4,1))
 
 
 class TestLinear(unittest.TestCase):
@@ -51,7 +51,7 @@ class TestLinear(unittest.TestCase):
     def test_f(self):
         l = Linear0(Halton(3))
         y = l.f_periodized(l.discrete_distrib.gen_samples(2**2),'c1sin')
-        self.assertTrue(y.shape==(4,))
+        self.assertTrue(y.shape==(4,1))
 
 
 class TestCustomFun(unittest.TestCase):
@@ -60,7 +60,7 @@ class TestCustomFun(unittest.TestCase):
     def test_f(self):
         cf = CustomFun(Uniform(Lattice(2)), lambda x: x.sum(1))
         y = cf.f_periodized(cf.discrete_distrib.gen_samples(2**2))
-        self.assertTrue(y.shape==(4,))
+        self.assertTrue(y.shape==(4,1))
 
 
 class TestCallOptions(unittest.TestCase):
@@ -75,7 +75,7 @@ class TestCallOptions(unittest.TestCase):
             self.assertTrue(d==true_d)
             mlco.true_measure._set_dimension_r(d)
             y = mlco.f_periodized(mlco.discrete_distrib.gen_samples(6),'c3sin',l=l)
-            self.assertTrue(y.shape==(6,))
+            self.assertTrue(y.shape==(6,1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- vectorize CubQMCCLT for integrands returning `dprime` outputs per input sample
- refactor and reorder output of `print(data)` to allow for multiple solution outputs and more readable objects
- patch Sobol's SciPy