### PR TITLE
Class install fixing package incompatibilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ test = [
     "testbook == 0.4.2",
     "psutil == 5.9.5",
     "parsl == 2025.7.28",
-    "seaborn == 0.8",
+    "seaborn >= 0.8",
     "scikit-learn >= 1.0.0",
     "scikit-optimize",
     "ipykernel",
@@ -83,13 +83,13 @@ test_torch = [
     "torch >= 2.7.0",
     ]
 test_gpytorch = [
-    "gpytorch == 1.11",
+    "gpytorch >= 1.11",
     ]
 test_botorch = [
-    "botorch == 0.10.0",
+    "botorch >= 0.10.0",
     ]
 test_umbridge = [
-    "umbridge == 1.2.4",
+    "umbridge >= 1.2.4",
     ]
 docs = [
     "nbval >= 0.10.0",


### PR DESCRIPTION
Thanks to my friends for merging class_install into develop.  When I tried 

[dev,class]

my preferred install, there are conflicts where some of the versions were pinned ==, that conflicted with others which were >=.  I have made some changes to resolve these.  

As python keeps advancing, I would hope that we could not use == unless absolutely necessary.