### PR TITLE
Fix test failures of v2.3 in master branch (#527)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0  

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We maintain a list of [publications on the development and use of QMCPy](https:/
 
 ### Package usage stats
 
-PyPI download statistics are tracked automatically in [stats/pypi_downloads.md](stats/pypi_downloads.md).
+PyPI download statistics are tracked automatically in [stats/pypi_downloads.md](https://github.com/QMCSoftware/QMCSoftware/blob/pypi-stats/stats/pypi_downloads.md) (in the pypi-stats branch).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We maintain a list of [publications on the development and use of QMCPy](https:/
 
 ### Package usage stats
 
-PyPI download statistics are tracked automatically in [stats/pypi_downloads.md](https://github.com/QMCSoftware/QMCSoftware/blob/pypi-stats/stats/pypi_downloads.md) (in the pypi-stats branch).
+PyPI download statistics are tracked automatically in [stats/pypi_downloads.md](stats/pypi_downloads.md).
 
 ## Development
 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
 # Emit pytest-xdist argument if available; can be overridden on the make command line
 PYTEST_XDIST ?= $(shell python scripts/pytest_xdist.py 2>/dev/null)
+PYTEST ?=
 
 # set environment variable for documentation
 export JUPYTER_PLATFORM_DIRS=1
@@ -159,7 +160,7 @@ booktests_parallel_pytest: check_booktests generate_booktests clean_local_only_f
 	cd test/booktests/ && \
 	PYTHONWARNINGS="ignore::UserWarning,ignore::DeprecationWarning,ignore::FutureWarning,ignore::ImportWarning" \
 	COVERAGE_FILE=../../$(BOOKTEST_COV_DIR)/.coverage \
-	python -W ignore -m pytest $(PYTEST_XDIST) -v tb_*.py \
+	python -W ignore -m pytest $(PYTEST_XDIST) $(PYTEST) -v tb_*.py \
 		--cov=qmcpy \
 		--cov-append \
 		--cov-report=term \


### PR DESCRIPTION
* Add __init__.py

* Update doc/tests.md

* Add spaces after commas in "(Union..."

* Update qmcpy/discrete_distribution/lattice/lattice.py



* Update qmcpy/discrete_distribution/lattice/lattice.py



* Update qmcpy/discrete_distribution/iid_std_uniform.py



* Initial plan (#464)



* Initial plan (#466)



* Initial plan (#472)



* Initial plan (#473)



* Initial plan (#471)



* Initial plan (#470)



* [WIP] Fix issues raised in feedback on documentation (#469)

* Initial plan

* Fix missing closing bracket in Union type hint



---------




* Initial plan (#468)



* Fix spelling errors in MaternGP docstring (#467)

* Initial plan

* Fix spelling errors: vectorfor -> vector for, multivariante -> multivariate



---------




* Fix missing closing bracket in Union type hint (#462)

* Initial plan

* Fix missing closing bracket in type hint for generating_matrices parameter



---------




* Fix spelling errors in MaternGP docstring (#463)

* Initial plan

* Fix spelling errors in matern_gp.py docstring



---------




* Fix spelling errors in MaternGP documentation (#465)

* Initial plan

* Fix spelling errors in matern_gp.py documentation



---------




* Fix typo

* Fix typos

* Fix typos

* [WIP] Enhance documentation (#474)

* Initial plan

* Fix documentation issues: remove quotes and add missing closing bracket



---------




* Adhere to PEP8

* Fix more typos

* Improve test assertions for better failure diagnostics (#475)

* Initial plan

* Replace assertTrue with assertEqual/assertLess and remove unused imports



---------




* +PEP8 scoring target

* Add missing spaces or brackets for better doc

* Fix makefile section header formatting inconsistency (#480)

* Initial plan

* Fix makefile section header borders to use 58 # characters



---------




* Update README.md

* Fix "make doc" error "ERROR   -  mkdocstrings: qmcpy.discrete_distributions.digital_net_any_bases.halton.Halton could not be found".

* Remove unreachable line of code

* Fix "make doc" warnings byadding jupytext metadata frontmatter to API pages

* Remove unused import

* Remove unused import

* Update test/README.md



* Remove unused import. Resolve Raising NoneType.

* Resolve possibly used before assignment

* Remove unused imports

* Fix "make doc" Warning: WARNING -  Doc file 'README.md' contains a link 'stats/pypi_downloads.md'

* Fix improper indentation

* Remove duplicate line

* remove reimport

* Fix errors I introduced earlier

* Add 'raise'

* Add raise

* Removed a deprecated warning and a WARNING

* Fix last warning in "make doc" related to print-site

* Fix code I broke earlier

* Add back imports

* Add PEP8 badge to README

* Replace tabs with spaces

* Fix log path. Remove and correct wrong info.

* Fix log path. Remove and correct wrong info.

* Revert changes from earlier today

* Remove duplicated file of stat/pypi_downloads.md

* Change mutable default argument to None

* Restrict import

* Remove 2 useless lines

* Change mutable default argument to None

* disable pylint warning

* Ignore pylint warnings of unused-import

* Remove unnecessary lambda function

* Remove unused variable.  Change mutable default argument to None

* Ignore pylint warnings of unused-import

* Update .github/workflows/pep8.yml



* Remove dead module-level platform config block in parsl_test_runner.py

Agent-Logs-Url: https://github.com/QMCSoftware/QMCSoftware/sessions/ce998eaf-a4e5-4968-babd-ee76e6778b8a



* Better exception handling

* Better exception handling

* Change mutable default argument to None

* Better exception handling

* Better exception handling

* Better exception handling

* Better exception handling

* Better exception handling

* Better exception handling

* Better exception handling

* Change push to PR

* Fix workflow for pep8

* Increase test coverage for integrands

* Increase test coverage for integrands

* Fix test failures and add tests for qmcpy.util.

* Remove one unit test

* Add tests for qmcpy.accumulate_data

* Update local pep8 badge

* Add test coverage for stopping_criterion

* Add tests to true_measure

* Add tests for integrands

* Clean up util tests

* Use MacOS for pep8

* Take out a failing test

* Fix different scores of remote and local workflow

* Fix different scores of remote and local workflow

* Fix different scores of remote and local workflow

* Fix different scores of remote and local workflow

* Update pylint badge

* Sync local and remote code coverage better for user branches

* Create tb_acceptance_rejection.py

* Fix test failure and warnings

* Update pep8 score

* Update PEP8 badge (#505)



* Fix a doc warning. Rearrange order of blogs.

* Remove unused variable

* Remove test

* Resolve pep8 issues

* Add demo

* Better exception handling

* Update pep8 score

* Ignore svg files

* Revert

* Add rendering script and styles for JOSS paper in MkDocs

* Add \$(PYTEST) to suppress slow notebooks

* Update PEP8 badge (#528)



* Disable Dependabot PR

* link README PyPI stats to live stats branch

* Update README to specify pypi-stats branch

Clarify the branch for PyPI download statistics.

---------