### PR TITLE
Adding Hammersley point set along as tests and documentation

### DIFF
--- a/docs/api/discrete_distributions.md
+++ b/docs/api/discrete_distributions.md
@@ -28,6 +28,10 @@ jupyter:
 
 ::: qmcpy.discrete_distribution.digital_net_any_bases.halton.Halton
 
+## `HammersleyPointSet`
+
+::: qmcpy.discrete_distribution.digital_net_any_bases.hammersley.HammersleyPointSet
+
 ## `Faure`
 
 ::: qmcpy.discrete_distribution.digital_net_any_bases.faure.Faure

--- a/docs/api/discrete_distributions.md
+++ b/docs/api/discrete_distributions.md
@@ -28,9 +28,9 @@ jupyter:
 
 ::: qmcpy.discrete_distribution.digital_net_any_bases.halton.Halton
 
-## `HammersleyPointSet`
+## `Hammersley`
 
-::: qmcpy.discrete_distribution.digital_net_any_bases.hammersley.HammersleyPointSet
+::: qmcpy.discrete_distribution.digital_net_any_bases.hammersley.Hammersley
 
 ## `Faure`
 

--- a/qmcpy/discrete_distribution/__init__.py
+++ b/qmcpy/discrete_distribution/__init__.py
@@ -2,7 +2,7 @@ from .abstract_discrete_distribution import AbstractDiscreteDistribution
 from .iid_std_uniform import IIDStdUniform
 from .lattice import Lattice
 from .digital_net_b2 import DigitalNetB2
-from .digital_net_any_bases import DigitalNetAnyBases,Halton,Faure,HammersleyPointSet
+from .digital_net_any_bases import DigitalNetAnyBases,Halton,Faure,Hammersley
 from .mpmc import MPMC
 from .kronecker import Kronecker
 

--- a/qmcpy/discrete_distribution/__init__.py
+++ b/qmcpy/discrete_distribution/__init__.py
@@ -2,7 +2,7 @@ from .abstract_discrete_distribution import AbstractDiscreteDistribution
 from .iid_std_uniform import IIDStdUniform
 from .lattice import Lattice
 from .digital_net_b2 import DigitalNetB2
-from .digital_net_any_bases import DigitalNetAnyBases,Halton,Faure
+from .digital_net_any_bases import DigitalNetAnyBases,Halton,Faure,HammersleyPointSet
 from .mpmc import MPMC
 from .kronecker import Kronecker
 

--- a/qmcpy/discrete_distribution/digital_net_any_bases/__init__.py
+++ b/qmcpy/discrete_distribution/digital_net_any_bases/__init__.py
@@ -1,3 +1,4 @@
 from .digital_net_any_bases import DigitalNetAnyBases
 from .halton import Halton
 from .faure import Faure
+from .hammersley import HammersleyPointSet

--- a/qmcpy/discrete_distribution/digital_net_any_bases/__init__.py
+++ b/qmcpy/discrete_distribution/digital_net_any_bases/__init__.py
@@ -1,4 +1,4 @@
 from .digital_net_any_bases import DigitalNetAnyBases
 from .halton import Halton
 from .faure import Faure
-from .hammersley import HammersleyPointSet
+from .hammersley import Hammersley

--- a/qmcpy/discrete_distribution/digital_net_any_bases/hammersley.py
+++ b/qmcpy/discrete_distribution/digital_net_any_bases/hammersley.py
@@ -7,7 +7,7 @@ import warnings
 
 
 
-class HammersleyPointSet(DigitalNetAnyBases):
+class Hammersley(DigitalNetAnyBases):
     r"""
     Hammersley point set: a deterministic, 'closed' low discrepancy point set.
 
@@ -34,7 +34,7 @@ class HammersleyPointSet(DigitalNetAnyBases):
           at index j" would be ambiguous for an array-valued `dimension`.
 
     Examples:
-        >>> discrete_distrib = HammersleyPointSet(4,seed=7)
+        >>> discrete_distrib = Hammersley(4,seed=7)
         >>> discrete_distrib(8,warn=False)
         array([[0.        , 0.        , 0.        , 0.        ],
                [0.125     , 0.5       , 0.33333333, 0.2       ],
@@ -47,7 +47,7 @@ class HammersleyPointSet(DigitalNetAnyBases):
 
         dimension=1 : only the i/n coordinate
 
-        >>> HammersleyPointSet(1)(4,warn=False)
+        >>> Hammersley(1)(4,warn=False)
         array([[0.  ],
                [0.25],
                [0.5 ],
@@ -68,15 +68,13 @@ class HammersleyPointSet(DigitalNetAnyBases):
     def __init__(self,
                  dimension=1,
                  seed=None,
-                 bases_generating_matrices=None,
                  t=None,
-                 alpha=1,
                  n_lim=2**32,
                  warn=True):
 
         if not np.isscalar(dimension):
             raise ParameterError(
-                "HammersleyPointSet does not support dimension as an array of "
+                "Hammersley does not support dimension as an array of "
                 "indices: unlike Halton, the i/n coordinate is not associated "
                 "with any prime index, so 'component at index j' is ambiguous "
                 "for this construction. Pass an int instead."
@@ -96,9 +94,7 @@ class HammersleyPointSet(DigitalNetAnyBases):
                 replications=None,
                 seed=seed,
                 randomize='None',
-                bases_generating_matrices=bases_generating_matrices,
                 t=t,
-                alpha=alpha,
                 n_lim=n_lim,
                 warn=warn)
         else:
@@ -107,15 +103,15 @@ class HammersleyPointSet(DigitalNetAnyBases):
 
     def _gen_samples(self, n_min, n_max, return_binary, warn):
         if return_binary:
-            raise ParameterError("HammersleyPointSet does not support return_binary=True")
+            raise ParameterError("Hammersley does not support return_binary=True")
         if n_min != 0:
             raise ParameterError(
-                "HammersleyPointSet requires n_min=0: the i/n coordinate "
+                "Hammersley requires n_min=0: the i/n coordinate "
                 "depends on the total number of points n."
             )
         if warn:
             warnings.warn(
-                "HammersleyPointSet is deterministic; the first point is "
+                "Hammersley is deterministic; the first point is "
                 "always the origin",
                 ParameterWarning,
             )
@@ -134,7 +130,7 @@ class HammersleyPointSet(DigitalNetAnyBases):
         return x
 
     def _spawn(self, child_seed, dimension):
-        return HammersleyPointSet(
+        return Hammersley(
             dimension=dimension,
             seed=child_seed,
         )                     

--- a/qmcpy/discrete_distribution/digital_net_any_bases/hammersley.py
+++ b/qmcpy/discrete_distribution/digital_net_any_bases/hammersley.py
@@ -71,6 +71,28 @@ class Hammersley(DigitalNetAnyBases):
                  t=None,
                  n_lim=2**32,
                  warn=True):
+        r"""
+        Args:
+            dimension (int): Dimension of the samples. Must be a scalar
+                `int` (unlike `Halton`, an array of indices is not
+                supported -- see class Notes).
+
+            seed (Union[None, int, np.random.SeedSequence]): Unused; kept
+                for API consistency with the other discrete distributions.
+                This point set is fully deterministic, so `seed` has no
+                effect on the generated points.
+
+            t (Union[None, int]): Passed through to the internal `Halton`
+                generator used for dimensions 2,...,`dimension` (ignored
+                when `dimension` is 1). See `Halton`'s docstring for
+                details.
+
+            n_lim (int): Maximum number of points `n` this distribution
+                can be asked to generate.
+
+            warn (bool): If `False`, disable the warning about the first
+                point always being the origin.
+        """
 
         if not np.isscalar(dimension):
             raise ParameterError(

--- a/qmcpy/discrete_distribution/digital_net_any_bases/hammersley.py
+++ b/qmcpy/discrete_distribution/digital_net_any_bases/hammersley.py
@@ -1,0 +1,140 @@
+from qmcpy.util import ParameterError,ParameterWarning
+import numpy as np
+from qmcpy.discrete_distribution.digital_net_any_bases.halton import Halton
+from qmcpy.discrete_distribution.abstract_discrete_distribution import AbstractLDDiscreteDistribution
+from .digital_net_any_bases import DigitalNetAnyBases
+import warnings
+
+
+
+class HammersleyPointSet(DigitalNetAnyBases):
+    r"""
+    Hammersley point set: a deterministic, 'closed' low discrepancy point set.
+
+    With $p_1,\dots,p_{d-1}$ the first $d-1$ prime numbers, the point set
+    $\{t_0,\dots,t_{n-1}\}$ with $n$ points in $d$ dimensions is given by
+    $t_i = (i/n,\ \varphi_{p_1}(i),\ \dots,\ \varphi_{p_{d-1}}(i))$
+    for $i=0,\dots,n-1$, where $\varphi_p$ denotes the radical inverse
+    function in base $p$.
+
+    Being a 'closed' point set (n must be fixed in advance, unlike an
+    extensible sequence such as Halton), the QMC error bound gains one
+    fewer power of $\log n$ than the corresponding Halton bound:
+    $|I_d(f)-Q_{n,d}(f)| \le C_d\, (\log n)^{d-1}/n\, V(f)$.
+
+    Note:
+        - This class is fully deterministic: no randomization is supported,
+          and the `seed` argument has no effect on the generated points.
+        - The first point is always the origin.
+        - Because the $i/n$ coordinate depends on the *total* number of
+          points $n$, this point set cannot be incrementally extended the
+          way `Halton` can: `n_min` must be 0.
+        - `dimension` must be an `int`: unlike `Halton`, the $i/n$
+          coordinate is not associated with any prime index, so "component
+          at index j" would be ambiguous for an array-valued `dimension`.
+
+    Examples:
+        >>> discrete_distrib = HammersleyPointSet(4,seed=7)
+        >>> discrete_distrib(8,warn=False)
+        array([[0.        , 0.        , 0.        , 0.        ],
+               [0.125     , 0.5       , 0.33333333, 0.2       ],
+               [0.25      , 0.25      , 0.66666667, 0.4       ],
+               [0.375     , 0.75      , 0.11111111, 0.6       ],
+               [0.5       , 0.125     , 0.44444444, 0.8       ],
+               [0.625     , 0.625     , 0.77777778, 0.04      ],
+               [0.75      , 0.375     , 0.22222222, 0.24      ],
+               [0.875     , 0.875     , 0.55555556, 0.44      ]])
+
+        dimension=1 : only the i/n coordinate
+
+        >>> HammersleyPointSet(1)(4,warn=False)
+        array([[0.  ],
+               [0.25],
+               [0.5 ],
+               [0.75]])
+
+    **References:**
+
+    1.  J. Dick, F. Y. Kuo, and I. H. Sloan.
+        High-dimensional integration: the quasi-Monte Carlo way.
+        Acta Numerica, 22:133-288. 2013.
+        [https://doi.org/10.1017/S0962492913000044](https://doi.org/10.1017/S0962492913000044).
+
+    2.  J. M. Hammersley.
+        Monte Carlo methods for solving multivariate problems.
+        Annals of the New York Academy of Sciences, 86(3):844-874. 1960.
+    """
+
+    def __init__(self,
+                 dimension=1,
+                 seed=None,
+                 bases_generating_matrices=None,
+                 t=None,
+                 alpha=1,
+                 n_lim=2**32,
+                 warn=True):
+
+        if not np.isscalar(dimension):
+            raise ParameterError(
+                "HammersleyPointSet does not support dimension as an array of "
+                "indices: unlike Halton, the i/n coordinate is not associated "
+                "with any prime index, so 'component at index j' is ambiguous "
+                "for this construction. Pass an int instead."
+            )
+        dimension = int(dimension)
+        if dimension < 1:
+            raise ParameterError("HammersleyPointSet requires dimension >= 1")
+        
+        AbstractLDDiscreteDistribution.__init__(
+            self, dimension, replications=None, seed=seed,
+            d_limit=10**9, n_limit=n_lim,
+        )
+
+        if dimension > 1:
+            self.halton = Halton(
+                dimension - 1,
+                replications=None,
+                seed=seed,
+                randomize='None',
+                bases_generating_matrices=bases_generating_matrices,
+                t=t,
+                alpha=alpha,
+                n_lim=n_lim,
+                warn=warn)
+        else:
+            self.halton = None
+        self.warn = warn
+
+    def _gen_samples(self, n_min, n_max, return_binary, warn):
+        if return_binary:
+            raise ParameterError("HammersleyPointSet does not support return_binary=True")
+        if n_min != 0:
+            raise ParameterError(
+                "HammersleyPointSet requires n_min=0: the i/n coordinate "
+                "depends on the total number of points n."
+            )
+        if warn:
+            warnings.warn(
+                "HammersleyPointSet is deterministic; the first point is "
+                "always the origin",
+                ParameterWarning,
+            )
+
+        n = int(n_max - n_min)
+        grid = (1 / n) * np.arange(n, dtype=np.float64)
+        grid = grid[None, :, None]                     # (1, n, 1)
+
+        if self.halton is None:
+            x = grid
+        else:
+            rest = self.halton.gen_samples(n_min=n_min, n_max=n_max,
+                                            return_binary=False, warn=False)
+            rest = rest[None, :, :]                      # (1, n, d-1)
+            x = np.concatenate([grid, rest], axis=-1)    # (1, n, d)
+        return x
+
+    def _spawn(self, child_seed, dimension):
+        return HammersleyPointSet(
+            dimension=dimension,
+            seed=child_seed,
+        )                     

--- a/test/test_discrete_distribs.py
+++ b/test/test_discrete_distribs.py
@@ -49,6 +49,7 @@ class TestDiscreteDistribution(unittest.TestCase):
             Lattice(d, seed=7),
             DigitalNetB2(d, seed=7),
             Halton(d, seed=7, warn=False),
+            HammersleyPointSet(d, seed=7, warn=False),
         ]:
             s = 3
             for spawn_dim in [4, [1, 4, 6]]:
@@ -345,6 +346,87 @@ class TestDigitalNetB2(unittest.TestCase):
                     self.assertTrue((x_full[:,4:16,:]==dnb2(4,16)).all())
 
 
+class TestHammersleyPointSet(unittest.TestCase):
+    """Unit tests for HammersleyPointSet discrete distribution."""
+
+    def test_gen_samples_shape(self):
+        distribution = HammersleyPointSet(dimension=3, seed=7)
+        x = distribution.gen_samples(8, warn=False)
+        self.assertEqual(x.shape, (8, 3))
+
+    def test_dimension_one(self):
+        distribution = HammersleyPointSet(dimension=1, seed=7)
+        x = distribution.gen_samples(4, warn=False)
+        true_sample = np.array([[0.0], [0.25], [0.5], [0.75]])
+        self.assertTrue((x == true_sample).all())
+
+    def test_values_in_unit_cube(self):
+        distribution = HammersleyPointSet(dimension=4, seed=7)
+        x = distribution.gen_samples(16, warn=False)
+        self.assertTrue((x >= 0).all() and (x < 1).all())
+
+    def test_first_point_is_origin(self):
+        distribution = HammersleyPointSet(dimension=3, seed=7)
+        x = distribution.gen_samples(8, warn=False)
+        self.assertTrue((x[0] == 0).all())
+
+    def test_matches_classical_definition(self):
+        # t_i = (i/n, phi_p1(i), ..., phi_p_{d-1}(i)) -- 
+        def van_der_corput(i, base):
+            f, r, idx = 1.0, 0.0, i
+            while idx > 0:
+                f /= base
+                r += f * (idx % base)
+                idx //= base
+            return r
+
+        primes = [2, 3, 5]
+        n, d = 8, 4
+        expected = np.array([
+            [i / n] + [van_der_corput(i, p) for p in primes]
+            for i in range(n)
+        ])
+        distribution = HammersleyPointSet(dimension=d, seed=7)
+        x = distribution.gen_samples(n, warn=False)
+        self.assertTrue(np.allclose(x, expected))
+
+
+    def test_array_dimension_raises(self):
+        with self.assertRaises(ParameterError):
+            HammersleyPointSet(dimension=[1, 3, 5], seed=7)
+
+    def test_dimension_less_than_one_raises(self):
+        with self.assertRaises(ParameterError):
+            HammersleyPointSet(dimension=0, seed=7)
+
+    def test_return_binary_raises(self):
+        distribution = HammersleyPointSet(dimension=2, seed=7)
+        with self.assertRaises(ParameterError):
+            distribution.gen_samples(4, return_binary=True, warn=False)
+
+    def test_n_min_nonzero_raises(self):
+        distribution = HammersleyPointSet(dimension=2, seed=7)
+        with self.assertRaises(ParameterError):
+            distribution.gen_samples(n_min=4, n_max=8, warn=False)
+
+    def test_warns_by_default(self):
+        distribution = HammersleyPointSet(dimension=2, seed=7)
+        with self.assertWarns(ParameterWarning):
+            distribution.gen_samples(8)
+
+    def test_no_warning_when_disabled(self):
+        distribution = HammersleyPointSet(dimension=2, seed=7)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            distribution.gen_samples(8, warn=False)
+
+    def test_spawn_dimension(self):
+        d = HammersleyPointSet(dimension=3, seed=7)
+        spawns = d.spawn(s=2, dimensions=[2, 4])
+        self.assertEqual(len(spawns), 2)
+        self.assertTrue(all(isinstance(s, HammersleyPointSet) for s in spawns))
+        self.assertEqual(spawns[0].d, 2)
+        self.assertEqual(spawns[1].d, 4)
 
 class TestHalton(unittest.TestCase):
     """Unit test for Halton DiscreteDistribution."""

--- a/test/test_discrete_distribs.py
+++ b/test/test_discrete_distribs.py
@@ -49,7 +49,7 @@ class TestDiscreteDistribution(unittest.TestCase):
             Lattice(d, seed=7),
             DigitalNetB2(d, seed=7),
             Halton(d, seed=7, warn=False),
-            HammersleyPointSet(d, seed=7, warn=False),
+            Hammersley(d, seed=7, warn=False),
         ]:
             s = 3
             for spawn_dim in [4, [1, 4, 6]]:
@@ -59,6 +59,9 @@ class TestDiscreteDistribution(unittest.TestCase):
                 self.assertTrue(
                     (np.array([spawn.d for spawn in spawns]) == spawn_dim).all()
                 )
+
+
+
 
 
 class TestLattice(unittest.TestCase):
@@ -346,32 +349,33 @@ class TestDigitalNetB2(unittest.TestCase):
                     self.assertTrue((x_full[:,4:16,:]==dnb2(4,16)).all())
 
 
-class TestHammersleyPointSet(unittest.TestCase):
-    """Unit tests for HammersleyPointSet discrete distribution."""
+
+class TestHammersley(unittest.TestCase):
+    """Unit tests for Hammersley discrete distribution."""
 
     def test_gen_samples_shape(self):
-        distribution = HammersleyPointSet(dimension=3, seed=7)
+        distribution = Hammersley(dimension=3, seed=7)
         x = distribution.gen_samples(8, warn=False)
         self.assertEqual(x.shape, (8, 3))
 
     def test_dimension_one(self):
-        distribution = HammersleyPointSet(dimension=1, seed=7)
+        distribution = Hammersley(dimension=1, seed=7)
         x = distribution.gen_samples(4, warn=False)
         true_sample = np.array([[0.0], [0.25], [0.5], [0.75]])
         self.assertTrue((x == true_sample).all())
 
     def test_values_in_unit_cube(self):
-        distribution = HammersleyPointSet(dimension=4, seed=7)
+        distribution = Hammersley(dimension=4, seed=7)
         x = distribution.gen_samples(16, warn=False)
         self.assertTrue((x >= 0).all() and (x < 1).all())
 
     def test_first_point_is_origin(self):
-        distribution = HammersleyPointSet(dimension=3, seed=7)
+        distribution = Hammersley(dimension=3, seed=7)
         x = distribution.gen_samples(8, warn=False)
         self.assertTrue((x[0] == 0).all())
 
     def test_matches_classical_definition(self):
-        # t_i = (i/n, phi_p1(i), ..., phi_p_{d-1}(i)) -- 
+        # t_i = (i/n, phi_p1(i), ..., phi_p_{d-1}(i)) --
         def van_der_corput(i, base):
             f, r, idx = 1.0, 0.0, i
             while idx > 0:
@@ -386,45 +390,44 @@ class TestHammersleyPointSet(unittest.TestCase):
             [i / n] + [van_der_corput(i, p) for p in primes]
             for i in range(n)
         ])
-        distribution = HammersleyPointSet(dimension=d, seed=7)
+        distribution = Hammersley(dimension=d, seed=7)
         x = distribution.gen_samples(n, warn=False)
         self.assertTrue(np.allclose(x, expected))
 
-
     def test_array_dimension_raises(self):
         with self.assertRaises(ParameterError):
-            HammersleyPointSet(dimension=[1, 3, 5], seed=7)
+            Hammersley(dimension=[1, 3, 5], seed=7)
 
     def test_dimension_less_than_one_raises(self):
         with self.assertRaises(ParameterError):
-            HammersleyPointSet(dimension=0, seed=7)
+            Hammersley(dimension=0, seed=7)
 
     def test_return_binary_raises(self):
-        distribution = HammersleyPointSet(dimension=2, seed=7)
+        distribution = Hammersley(dimension=2, seed=7)
         with self.assertRaises(ParameterError):
             distribution.gen_samples(4, return_binary=True, warn=False)
 
     def test_n_min_nonzero_raises(self):
-        distribution = HammersleyPointSet(dimension=2, seed=7)
+        distribution = Hammersley(dimension=2, seed=7)
         with self.assertRaises(ParameterError):
             distribution.gen_samples(n_min=4, n_max=8, warn=False)
 
     def test_warns_by_default(self):
-        distribution = HammersleyPointSet(dimension=2, seed=7)
+        distribution = Hammersley(dimension=2, seed=7)
         with self.assertWarns(ParameterWarning):
             distribution.gen_samples(8)
 
     def test_no_warning_when_disabled(self):
-        distribution = HammersleyPointSet(dimension=2, seed=7)
+        distribution = Hammersley(dimension=2, seed=7)
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             distribution.gen_samples(8, warn=False)
 
     def test_spawn_dimension(self):
-        d = HammersleyPointSet(dimension=3, seed=7)
+        d = Hammersley(dimension=3, seed=7)
         spawns = d.spawn(s=2, dimensions=[2, 4])
         self.assertEqual(len(spawns), 2)
-        self.assertTrue(all(isinstance(s, HammersleyPointSet) for s in spawns))
+        self.assertTrue(all(isinstance(s, Hammersley) for s in spawns))
         self.assertEqual(spawns[0].d, 2)
         self.assertEqual(spawns[1].d, 4)
 


### PR DESCRIPTION
## Summary
- Issue: Add Hammersley point set discrete distribution #572
- Algorithmic or API impact: Adds a new `HammersleyPointSet` discrete distribution class. 
Purely additive: no existing class, method, or public API signature is modified. The implementation reuses `Halton` internally (constructing a `d-1` dimensional unrandomized `Halton` instance for the radical-inverse coordinates) and prepends the `i/n` coordinate. This first version includes **no randomization**: the distribution is fully deterministic, `seed` has no effect on the generated points, and `dimension` must be a scalar int (unlike `Halton`, the `i/n` coordinate has no associated prime index). Exported via `qmcpy/discrete_distribution/__init__.py` alongside the other discrete distributions.
- Commands run:
  - `python -m pytest test/test_discrete_distribs.py -v`
  - `python -m pytest test/ -q` (full suite)
  - `python -m doctest qmcpy/discrete_distribution/hammersley.py -v`
  - `mkdocs build --strict`
  - `make doc`

## AI Assistance
- [ ] No substantive AI assistance was used for this PR.
- [x] AI assistance substantively affected this PR, and I describe that use below.

AI tools and affected areas: I used an AI assistant (Claude) throughout this PR, but I directed the design decisions and verified every change myself (running tests, doctests, and reproducing behavior independently rather than accepting output as-is), including catching several issues in my own drafts along the way.

- [x] Independent verification performed.

I ran the full test suite and doctests myself after each change and confirmed all pass locally.

## Checklist
- [x] I linked the relevant issue or explained why none was needed.
- [x] I added or updated tests, docs, notebooks, or explained why they were not needed.
- [x] I verified any equations, citations, benchmarks, numerical claims, or external references changed in this PR.
- [x] I reviewed AI-assisted content for licensing, provenance, attribution, confidentiality, and security concerns.
- [x] I described any CI, dependency, notebook runtime, or generated artifact changes if applicable.

No new dependencies are introduced by this PR. No new data files are added . 

Closes #572
